### PR TITLE
Implement search-up functionality for pyproject.toml files

### DIFF
--- a/src/pywrangler/cli.py
+++ b/src/pywrangler/cli.py
@@ -5,7 +5,6 @@ import textwrap
 import click
 
 from pywrangler.sync import (
-    check_pyproject_toml,
     check_requirements_txt,
     is_sync_needed,
     create_pyodide_venv,
@@ -108,8 +107,7 @@ def sync_command(force=False):
 
     Also creates a virtual env for Workers that you can use for testing.
     """
-    # Check if pyproject.toml exists and requirements.txt does not
-    check_pyproject_toml()
+    # Check if requirements.txt does not exist.
     check_requirements_txt()
 
     # Check if sync is needed based on file timestamps

--- a/src/pywrangler/sync.py
+++ b/src/pywrangler/sync.py
@@ -5,7 +5,11 @@ import tempfile
 
 import click
 
-from pywrangler.utils import get_vendor_path_from_wrangler_config, run_command
+from pywrangler.utils import (
+    get_vendor_path_from_wrangler_config,
+    run_command,
+    find_pyproject_toml,
+)
 
 try:
     import tomllib  # Standard in Python 3.11+
@@ -15,17 +19,11 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 # Define paths
-PROJECT_ROOT = Path.cwd()  # Assumes script is run from project root
+PYPROJECT_TOML_PATH = find_pyproject_toml()
+PROJECT_ROOT = PYPROJECT_TOML_PATH.parent
 VENV_WORKERS_PATH = PROJECT_ROOT / ".venv-workers"
 PYODIDE_VENV_PATH = VENV_WORKERS_PATH / "pyodide-venv"
-PYPROJECT_TOML_PATH = PROJECT_ROOT / "pyproject.toml"
 VENV_REQUIREMENTS_PATH = VENV_WORKERS_PATH / "temp-venv-requirements.txt"
-
-
-def check_pyproject_toml():
-    if not PYPROJECT_TOML_PATH.is_file():
-        logger.error(f"{PYPROJECT_TOML_PATH} not found.")
-        raise click.exceptions.Exit(code=1)
 
 
 def check_requirements_txt():

--- a/src/pywrangler/utils.py
+++ b/src/pywrangler/utils.py
@@ -153,3 +153,26 @@ def get_vendor_path_from_wrangler_config(project_path: Path) -> Path:
     vendor_path_relative_to_project = base_dir_relative_to_project / "vendor"
 
     return vendor_path_relative_to_project
+
+
+def find_pyproject_toml() -> Path:
+    """
+    Search for pyproject.toml starting from current working directory and going up the directory tree.
+
+    Returns:
+        Path to pyproject.toml if found.
+
+    Raises:
+        click.exceptions.Exit: If pyproject.toml is not found in the directory tree.
+    """
+
+    parent_dirs = (Path.cwd().resolve() / "dummy").parents
+    for current_dir in parent_dirs:
+        pyproject_path = current_dir / "pyproject.toml"
+        if pyproject_path.is_file():
+            return pyproject_path
+
+    logger.error(
+        f"pyproject.toml not found in {Path.cwd().resolve()} or any parent directories"
+    )
+    raise click.exceptions.Exit(code=1)


### PR DESCRIPTION
The pywrangler tool now searches upward from the current working directory to find pyproject.toml files.

🤖 Generated with [Claude Code](https://claude.ai/code)

<details><summary>Cost</summary>
<p>

```
> /cost 
  ⎿  Total cost:            $1.10
     Total duration (API):  19m 55.9s
     Total duration (wall): 42m 52.5s
     Total code changes:    161 lines added, 72 lines removed
     Token usage by model:
         claude-3-5-haiku:  116.5k input, 5.0k output, 0 cache read, 0 cache write
            claude-sonnet:  657 input, 15.0k output, 1.9m cache read, 51.5k cache write
```

</p>
</details> 

### Test Plan

```
$ uv run pytest tests/test_cli.py::test_sync_command_finds_pyproject_in_parent_directory tests/test_cli.py::test_sync_command_handles_missing_pyproject -v
```
