### PR TITLE
fix: skip Upload Distribution Artifacts step on tagged commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
 
       - name: Upload | Distribution Artifacts
         uses: actions/upload-artifact@v4
+        if: steps.release.outputs.released == 'true'
         with:
           name: distribution-artifacts
           path: dist


### PR DESCRIPTION
I see that other projects that use python-semantic-release skip this step, like https://github.com/RIVM-bioinformatics/gen-epix-api/blob/625bae2c34a2e2534d76f1776898874b3ec49336/.github/workflows/release.yaml#L60. So hopefully this fixes the issue we're seeing in https://github.com/cloudflare/workers-py/actions/runs/15713993288/job/44279042508