### PR TITLE
fix: only look for pyproject.toml on `sync` command

### DIFF
--- a/src/pywrangler/cli.py
+++ b/src/pywrangler/cli.py
@@ -4,15 +4,6 @@ import sys
 import textwrap
 import click
 
-from pywrangler.sync import (
-    check_requirements_txt,
-    is_sync_needed,
-    create_pyodide_venv,
-    create_workers_venv,
-    parse_requirements,
-    install_pyodide_build,
-    install_requirements,
-)
 from pywrangler.utils import setup_logging, write_success
 
 setup_logging()
@@ -107,6 +98,17 @@ def sync_command(force=False):
 
     Also creates a virtual env for Workers that you can use for testing.
     """
+    # This module is imported locally because it searches for pyproject.toml at the top-level.
+    from pywrangler.sync import (
+        check_requirements_txt,
+        is_sync_needed,
+        create_pyodide_venv,
+        create_workers_venv,
+        parse_requirements,
+        install_pyodide_build,
+        install_requirements,
+    )
+
     # Check if requirements.txt does not exist.
     check_requirements_txt()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,8 +10,9 @@ import pytest
 from click.testing import CliRunner
 
 # Import the full module so we can patch constants
-import pywrangler.cli
 from pywrangler.cli import app
+import pywrangler.sync as pywrangler_sync
+
 
 # Define test fixtures and constants
 TEST_DIR = Path(__file__).parent / "test_workspace"
@@ -243,11 +244,11 @@ def test_sync_command_handles_missing_pyproject():
         assert result.returncode != 0
 
         # Check that the error was logged
-        assert "pyproject.toml not found" in result.stderr
+        assert "pyproject.toml not found" in result.stdout
 
 
-@patch("pywrangler.cli.is_sync_needed")
-@patch("pywrangler.cli.install_requirements")
+@patch.object(pywrangler_sync, "is_sync_needed")
+@patch.object(pywrangler_sync, "install_requirements")
 def test_sync_command_with_unchanged_timestamps(
     mock_install_requirements, mock_is_sync_needed, clean_test_dir, caplog
 ):
@@ -273,8 +274,8 @@ def test_sync_command_with_unchanged_timestamps(
     mock_install_requirements.assert_not_called()
 
 
-@patch("pywrangler.cli.is_sync_needed")
-@patch("pywrangler.cli.install_requirements")
+@patch.object(pywrangler_sync, "is_sync_needed")
+@patch.object(pywrangler_sync, "install_requirements")
 def test_sync_command_with_changed_timestamps(
     mock_install_requirements, mock_is_sync_needed, clean_test_dir, caplog
 ):
@@ -299,8 +300,8 @@ def test_sync_command_with_changed_timestamps(
     mock_install_requirements.assert_called_once()
 
 
-@patch("pywrangler.cli.is_sync_needed")
-@patch("pywrangler.cli.install_requirements")
+@patch.object(pywrangler_sync, "is_sync_needed")
+@patch.object(pywrangler_sync, "install_requirements")
 def test_sync_command_with_force_flag(
     mock_install_requirements, mock_is_sync_needed, clean_test_dir, caplog
 ):
@@ -326,8 +327,8 @@ def test_sync_command_with_force_flag(
     mock_install_requirements.assert_called_once()
 
 
-@patch.object(pywrangler.sync, "PROJECT_ROOT", TEST_DIR)
-@patch.object(pywrangler.sync, "PYPROJECT_TOML_PATH", TEST_PYPROJECT)
+@patch.object(pywrangler_sync, "PROJECT_ROOT", TEST_DIR)
+@patch.object(pywrangler_sync, "PYPROJECT_TOML_PATH", TEST_PYPROJECT)
 def test_sync_command_handles_missing_wrangler_config(clean_test_dir, caplog):
     """Test that the sync command correctly handles missing wrangler configuration files."""
     # Create a pyproject.toml file but don't create wrangler config files
@@ -348,9 +349,9 @@ def test_sync_command_handles_missing_wrangler_config(clean_test_dir, caplog):
     assert "not found" in caplog.text
 
 
-@patch.object(pywrangler.sync, "PROJECT_ROOT", TEST_DIR)
-@patch.object(pywrangler.sync, "VENV_WORKERS_PATH", TEST_DIR / ".venv-workers")
-@patch.object(pywrangler.sync, "PYPROJECT_TOML_PATH", TEST_PYPROJECT)
+@patch.object(pywrangler_sync, "PROJECT_ROOT", TEST_DIR)
+@patch.object(pywrangler_sync, "VENV_WORKERS_PATH", TEST_DIR / ".venv-workers")
+@patch.object(pywrangler_sync, "PYPROJECT_TOML_PATH", TEST_PYPROJECT)
 def test_sync_command_with_wrangler_toml(clean_test_dir, caplog):
     """Test that the sync command correctly processes wrangler.toml files."""
     # Create the necessary files

--- a/uv.lock
+++ b/uv.lock
@@ -391,8 +391,33 @@ wheels = [
 ]
 
 [[package]]
+name = "uv"
+version = "0.5.31"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/04/63265828848c2ca60e322408ed529587f670ee97c5607114df08c389398a/uv-0.5.31.tar.gz", hash = "sha256:59c4c6e3704208a8dd5e8d51b79ec995db18a64bd3ff88fd239ca433fbaf1694", size = 2875508 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/80/58942f09e0a38fdef37d54d553175e3c195da32547711c78dcc70876f2ce/uv-0.5.31-py3-none-linux_armv6l.whl", hash = "sha256:ba5707a6e363284ba1acd29ae9e70e2377ed31e272b953069798c444bae847ef", size = 15475386 },
+    { url = "https://files.pythonhosted.org/packages/a2/ed/1605df7bd74eac86975a48e16a76ae04feedc9d27dc841e8d4f3c00a790f/uv-0.5.31-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3169a373d0d41571a7b9d4a442f875f6e26250693ced7779f62461f52ba1da64", size = 15608043 },
+    { url = "https://files.pythonhosted.org/packages/1f/5a/1eb42f481a9f9010c8c194d70ab375a6eda96d67ca1fd011bf869d4016c8/uv-0.5.31-py3-none-macosx_11_0_arm64.whl", hash = "sha256:335c16f91b46b4f4a3b31c18cf112a0643d59d4c1708a177103621da0addbaef", size = 14523527 },
+    { url = "https://files.pythonhosted.org/packages/9a/05/9817ea1f0d8e7134ed60abeefa7bdc602f4a4a6e2ccdf2760b54fb3dcef3/uv-0.5.31-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:cedceefebf2123b514464671d0544a8db126071c2d56dbc10d408b8222939e6a", size = 14940294 },
+    { url = "https://files.pythonhosted.org/packages/e4/2d/aee8e68026057c6db71424e3a312d739af8838ae35321bfa1f5900e93d1c/uv-0.5.31-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7233182a2b8226011562341f05aaee19925b48730fccdb2e7ee20e31a84f12db", size = 15211133 },
+    { url = "https://files.pythonhosted.org/packages/58/cf/16c3b71c903e7d8c3aeb0b85efbf2efb4694ffeab72165d7d9166bf2d497/uv-0.5.31-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9ce4dc079fd5ddf1946e6085b6ece126ce7c4be23ba27e4010aa68fdec004191", size = 15943734 },
+    { url = "https://files.pythonhosted.org/packages/7c/28/8421b94710581c81a9240df95f04b87cfffd5da229eb178733acb6d1a6de/uv-0.5.31-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:007576e1b62268d4a21d4a375d43ff5ae3698313a11f7702c8e7cb5bd29d7f1b", size = 16890117 },
+    { url = "https://files.pythonhosted.org/packages/be/9c/a3d4318aebbc68158dc069d3f8de423d56ec3a38017401e92e9e37fe5afc/uv-0.5.31-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:51d8287cdb760ea8c44b374cb96a59fae2292f1b3e18e228f7ed817d2bd96243", size = 16623168 },
+    { url = "https://files.pythonhosted.org/packages/dd/b1/32a5e1239eca3915bec3825dab8c635f80c64b09ae46cf03d1bef7641892/uv-0.5.31-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:27ce8f3eecd281a6ec255644a328b60eb10044e506a46be931db7bbfe8db89ab", size = 20939390 },
+    { url = "https://files.pythonhosted.org/packages/ce/2e/0c3ac2f5be92492cbe735de7f66a83b2d3e22bd59554deaa0106562cba45/uv-0.5.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d07e9db12a55005a28bb49ecfa444a0221702158fc021f79e26d8e174f1ebdf9", size = 16293460 },
+    { url = "https://files.pythonhosted.org/packages/cc/de/59e6665d9f1d4fc93c0b3383eaf31dbf7088cf8fce5c239b5eb8f0bf911b/uv-0.5.31-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:8acf6bcb0c0c27e1a157926f35dc70b1c7620c1a2e1124ffacdbf21c78265761", size = 15234496 },
+    { url = "https://files.pythonhosted.org/packages/32/14/e69d04bc77f73a34d2d850d60cf21ded8cf0f3481302ea31533ad5a64733/uv-0.5.31-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:a8f27ea8441ce9de43a6af4825d2b936030a0a6864c608f1015db30e9f5f9cdb", size = 15212989 },
+    { url = "https://files.pythonhosted.org/packages/99/29/1afb24345ffa6dd351170adc9b30d8a3855c47a2b85f093f28b7366c2a6d/uv-0.5.31-py3-none-musllinux_1_1_i686.whl", hash = "sha256:e6b5a29c29e774525baf982f570c53e8862f19e3f7e74bd819c7b3749f4cdfa0", size = 15554448 },
+    { url = "https://files.pythonhosted.org/packages/5a/5f/784cbe68aa0c291587a3735a61372dc02521780ccd0f0058f159a451df19/uv-0.5.31-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:15109a938c56ee1e1c997b291743812af3ea1d7547b0929569494c359082a993", size = 16405791 },
+    { url = "https://files.pythonhosted.org/packages/9f/80/458b8f67e41dddc3c6ca1515ea8136c217a52b92dedd8c53f9eb00287d22/uv-0.5.31-py3-none-win32.whl", hash = "sha256:f2161ef8b9a0308f05dd4a3eb2c1d104301e23c699fab5898e9fc38387690e4b", size = 15602489 },
+    { url = "https://files.pythonhosted.org/packages/4c/50/f3f89c6bd27aae15ca3150b839c9d8f5d32a9a19a6eae3daa6d9aae1de4f/uv-0.5.31-py3-none-win_amd64.whl", hash = "sha256:bcc57b75883516233658ff1daee0d17347a8b872f717a1644d36e8ea2b021f45", size = 16895932 },
+    { url = "https://files.pythonhosted.org/packages/12/64/af4aa07bc1c525b1fefd1686d31a43a74eac51e74046755ffdca4502784d/uv-0.5.31-py3-none-win_arm64.whl", hash = "sha256:51ceab5a128dd22bcd62489107563e10084e13ed9c15107193c2d7d1139979f4", size = 15776619 },
+]
+
+[[package]]
 name = "workers-py"
-version = "0.1.0"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -401,6 +426,11 @@ dependencies = [
     { name = "pyodide-cli", version = "0.2.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "pyodide-cli", version = "0.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "rich" },
+]
+
+[package.optional-dependencies]
+build = [
+    { name = "uv" },
 ]
 
 [package.dev-dependencies]
@@ -419,6 +449,7 @@ requires-dist = [
     { name = "commentjson", specifier = ">=0.9.0" },
     { name = "pyodide-cli" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "uv", marker = "extra == 'build'", specifier = "~=0.5.23" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
The sync module calls find_pyproject_toml at the top-level, so it gets imported even on non-sync commands. This PR moves the import under the `sync` function so it only gets evaluated when the sync command is executed.

### Test Plan

<details><summary>Before:</summary>
<p>

```
➜ uv run --project ~/repos/workers-py ~/repos/workers-py/src/pywrangler --help
No cache entries found
   Built workers-py @ file:///Users/dominik/repos/workers-py
Uninstalled 1 package in 1ms
Installed 1 package in 2ms
pyproject.toml not found in /Users/dominik or any parent directories
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/dominik/repos/workers-py/src/pywrangler/__main__.py", line 1, in <module>
    from pywrangler.cli import app
  File "/Users/dominik/repos/workers-py/src/pywrangler/cli.py", line 7, in <module>
    from pywrangler.sync import (
  File "/Users/dominik/repos/workers-py/src/pywrangler/sync.py", line 22, in <module>
    PYPROJECT_TOML_PATH = find_pyproject_toml()
                          ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dominik/repos/workers-py/src/pywrangler/utils.py", line 178, in find_pyproject_toml
    raise click.exceptions.Exit(code=1)
click.exceptions.Exit

~ via ⬢ v23.7.0 

```

</p>
</details> 


<details><summary>After:</summary>
<p>


```
➜ uv run --project ~/repos/workers-py ~/repos/workers-py/src/pywrangler --help
No cache entries found
Usage: pywrangler [OPTIONS] COMMAND [ARGS]...

  A CLI tool for Cloudflare Workers. Use 'sync' command for Python package
  setup. All other commands are proxied to 'wrangler', with `dev` and `deploy`
  automatically running `sync` first before proxying.

Options:
  --debug    Enable debug logging
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  sync  Installs Python packages from pyproject.toml into src/vendor.

Wrangler Commands (proxied):
  wrangler

  COMMANDS
    pywrangler docs [search..]        📚 Open Wrangler's command documentation in your browser

    pywrangler init [name]            📥 Initialize a basic Worker
    pywrangler dev [script]           👂 Start a local server for developing your Worker
    pywrangler deploy [script]        🆙 Deploy a Worker to Cloudflare
    pywrangler deployments            🚢 List and view the current and past deployments for your Worker
    pywrangler rollback [version-id]  🔙 Rollback a deployment for a Worker
    pywrangler versions               🫧  List, view, upload and deploy Versions of your Worker to Cloudflare
    pywrangler triggers               🎯 Updates the triggers of your current deployment [experimental]
    pywrangler delete [script]        🗑  Delete a Worker from Cloudflare
    pywrangler tail [worker]          🦚 Start a log tailing session for a Worker
    pywrangler secret                 🤫 Generate a secret that can be referenced in a Worker
    pywrangler types [path]           📝 Generate types from your Worker configuration

    pywrangler kv                     🗂️  Manage Workers KV Namespaces
    pywrangler queues                 🇶  Manage Workers Queues
    pywrangler r2                     📦 Manage R2 buckets & objects
    pywrangler d1                     🗄  Manage Workers D1 databases
    pywrangler vectorize              🧮 Manage Vectorize indexes
    pywrangler hyperdrive             🚀 Manage Hyperdrive databases
    pywrangler cert                   🪪 Manage client mTLS certificates and CA certificate chains used for secured connections [open-beta]
    pywrangler pages                  ⚡️ Configure Cloudflare Pages
    pywrangler mtls-certificate       🪪  Manage certificates used for mTLS connections
    pywrangler pubsub                 📮 Manage Pub/Sub brokers [private beta]
    pywrangler dispatch-namespace     🏗️  Manage dispatch namespaces
    pywrangler ai                     🤖 Manage AI models
    pywrangler secrets-store          🔐 Manage the Secrets Store [alpha]
    pywrangler workflows              🔁 Manage Workflows
    pywrangler pipelines              🚰 Manage Cloudflare Pipelines [open-beta]
    pywrangler login                  🔓 Login to Cloudflare
    pywrangler logout                 🚪 Logout from Cloudflare
    pywrangler whoami                 🕵️  Retrieve your user information

  GLOBAL FLAGS
    -c, --config   Path to Wrangler configuration file  [string]
        --cwd      Run as if Wrangler was started in the specified directory instead of the current working directory  [string]
    -e, --env      Environment to use for operations, and for selecting .env and .dev.vars files  [string]
    -h, --help     Show help  [boolean]
    -v, --version  Show version number  [boolean]

  Please report any issues to https://github.com/cloudflare/workers-sdk/issues/new/choose
```

</p>
</details> 
