### PR TITLE
fix: mark python_modules as a virtual env dir

### DIFF
--- a/src/pywrangler/sync.py
+++ b/src/pywrangler/sync.py
@@ -171,6 +171,10 @@ def _install_requirements_to_vendor(requirements: list[str]):
                 str(temp_file_path),
             ]
         )
+
+        # Create a pyvenv.cfg file in python_modules to mark it as a virtual environment
+        (vendor_path / "pyvenv.cfg").touch()
+
         logger.info(
             f"Packages installed in [bold]{relative_vendor_path}[/bold].",
             extra={"markup": True},

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -186,6 +186,12 @@ def test_sync_command_integration(dependencies, clean_test_dir):
                 f"python_modules directory should be empty of packages but contains: {list(TEST_SRC_VENDOR.iterdir())}"
             )
 
+    # Verify that pyvenv.cfg is created only when there are dependencies
+    if test_deps:
+        assert (TEST_SRC_VENDOR / "pyvenv.cfg").exists(), (
+            f"pyvenv.cfg was not created in {TEST_SRC_VENDOR}"
+        )
+
     # Check .venv-workers directory exists and has the expected packages
     TEST_VENV_WORKERS = TEST_DIR / ".venv-workers"
     assert TEST_VENV_WORKERS.exists(), (


### PR DESCRIPTION
This is to stop `pytest` from searching through it for test files and inadvertently adding it to the search path when running tests.