### PR TITLE
feat: adds wrangler version check

### DIFF
--- a/src/pywrangler/cli.py
+++ b/src/pywrangler/cli.py
@@ -57,6 +57,11 @@ class ProxyToWranglerGroup(click.Group):
             if cmd_name in ["dev", "publish", "deploy", "versions"]:
                 ctx.invoke(sync_command, force=False, directly_requested=False)
 
+            if cmd_name == "dev":
+                from pywrangler.sync import check_wrangler_version
+
+                check_wrangler_version()
+
             _proxy_to_wrangler(cmd_name, remaining_args)
             sys.exit(0)
 


### PR DESCRIPTION
I ran into this myself, so others will undoubtedly too. This is just a simple change to add a wrangler version check to ensure the user has the right version of Wrangler. If the version is too old it may not support vendored packages correctly and fail in surprising ways, so this should ensure that doesn't happen to anyone.