### PR TITLE
feat: pywrangler init proxies to C3 directly with Python preselected

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,13 @@ uv run pywrangler sync
 
 ### Development
 
-To run the CLI tool while developing it, use:
-
-```bash
-export REPO_ROOT=/path/to/repo
-uv run --project $REPO_ROOT $REPO_ROOT/src/pywrangler --help
-```
-
-On Linux, to install it globally, you may also be able to run:
+To run the CLI tool while developing it, install it globally:
 
 ```
 uv tool install -e .
 ```
+
+Then run it via `pywrangler`.
 
 Alternatively, you can add `workers-py` to your pyproject.toml:
 

--- a/src/pywrangler/utils.py
+++ b/src/pywrangler/utils.py
@@ -7,6 +7,7 @@ from rich.logging import Console, RichHandler
 from rich.theme import Theme
 
 WRANGLER_COMMAND = ["npx", "--yes", "wrangler"]
+WRANGLER_CREATE_COMMAND = ["npx", "--yes", "create-cloudflare"]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
We pass a few flags to C3 to change its behaviour:

* --lang=python preselects Python, so that the user doesn't have to select python again when using `pywrangler init`
* --no-deploy avoids asking the user whether they wish to deploy, we do this because a template may contain packages that need to be vendored first, in which case `wrangler deploy` would fail, we prefer the user to run `pywrangler deploy` which will ensure vendoring happens first

C3 will also suggest to the user to run `npm run start` and `npm run deploy`. I've created a separate PR to make sure those scripts run pywrangler here: https://github.com/cloudflare/workers-sdk/pull/10990.