### PR TITLE
fix: be more lenient with wrangler version parsing

### DIFF
--- a/src/pywrangler/sync.py
+++ b/src/pywrangler/sync.py
@@ -263,7 +263,7 @@ def check_wrangler_version():
     # Parse version from output like "wrangler 4.42.1" or " ⛅️ wrangler 4.42.1"
     version_line = result.stdout.strip()
     # Extract version number using regex
-    version_match = re.search(r"wrangler\s+(\d+)\.(\d+)\.(\d+)", version_line)
+    version_match = re.search(r"(\d+)\.(\d+)\.(\d+)", version_line)
 
     if not version_match:
         logger.error(f"Could not parse wrangler version from: {version_line}")


### PR DESCRIPTION
I got this error locally:

```
ERROR    Could not parse wrangler version from: 4.43.0                                                                                                                                                                                                      
ERROR    Install wrangler with: npm install wrangler@latest  
```

I'm not really sure how... running `npx wrangler --version` locally returned `wrangler 4.43.0`. But in any case, it's probably best to avoid requiring the "wrangler" to be present there anyway.