### PR TITLE
feat: better errors when unsupported packages are requested

### DIFF
--- a/src/pywrangler/utils.py
+++ b/src/pywrangler/utils.py
@@ -79,20 +79,24 @@ def run_command(
     """
     logger.log(RUNNING_LEVEL, f"{' '.join(str(arg) for arg in command)}")
     try:
+        kwargs = {}
+        if capture_output:
+            kwargs = dict(stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
         process = subprocess.run(
             command,
             cwd=cwd,
             env=env,
             check=check,
-            capture_output=capture_output,
             text=True,
-        )
+            **kwargs,
+        )  # type: ignore[call-overload]
         if process.stdout and not capture_output:
             logger.log(OUTPUT_LEVEL, f"{process.stdout.strip()}")
-        return process
+        return process  # type: ignore[no-any-return]
     except subprocess.CalledProcessError as e:
         logger.error(
-            f"Error running command: {' '.join(str(arg) for arg in command)}\nExit code: {e.returncode}\nOutput:\n{e.stdout.strip() if e.stdout else ''}{e.stderr.strip() if e.stderr else ''}"
+            f"Error running command: {' '.join(str(arg) for arg in command)}\nExit code: {e.returncode}\nOutput:\n{e.stdout.strip() if e.stdout else ''}"
         )
         raise click.exceptions.Exit(code=e.returncode) from None
     except FileNotFoundError:


### PR DESCRIPTION
* output is now captured for uv commands
* packages are now installed to venv first
* this enables us to determine the cause of installation errors more accurately
* error messages are now clear about the cause of the failure and let the user know if a package is unsupported by python workers

### Test Plan

* with package version that works in native python but not in pyodide

```
$ uv tool install -e . # install dev copy of pywrangler
# in wrangler project with "dspy==3.0.3" in pyproject.toml
$ pywrangler sync 
INFO     Found 2 dependencies.                                                                                                                                                                                                               
INFO     Installing packages into .venv-workers...                                                                                                                                                                                           
INFO     Packages installed in .venv-workers.                                                                                                                                                                                                
INFO     Installing packages into python_modules...                                                                                                                                                                                          
WARNING  Using Python 3.13.2 environment at: .venv-workers/pyodide-venv                                                                                                                                                                      
           × No solution found when resolving dependencies:
....
ERROR    Installation failed because the packages you requested are not supported by Python Workers. See above for details.
```

* with package version that doesn't exist at all

```
# in wrangler project with "dspy==4.0.3" in pyproject.toml
$ pywrangler sync   
INFO     Found 2 dependencies.                                                                                                                                                                                                               
INFO     Installing packages into .venv-workers...                                                                                                                                                                                           
WARNING  Using Python 3.13.1 environment at: .venv-workers                                                                                                                                                                                   
           × No solution found when resolving dependencies:                                                                                                                                                                                  
           ╰─▶ Because there is no version of dspy==4.0.3 and you require dspy==4.0.3, we can conclude that your requirements are unsatisfiable.                                                                                             
ERROR    Failed to install the requirements defined in your pyproject.toml file. See above for details.
```