### PR TITLE
chore: run type tests only in Python>=3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.12']
+        python-version: ['3.12', '3.13']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,8 @@
+import sys
 from contextlib import chdir
 from subprocess import run
+
+import pytest
 
 # Import the full module so we can patch constants
 from pywrangler.types import wrangler_types
@@ -42,7 +45,9 @@ class Default(WorkerEntrypoint):
 """
 
 
+@pytest.mark.skipif(sys.version_info < (3, 13), reason="We create Python 3.13+ syntax")
 def test_types(tmp_path):
+    """Test that types are correctly revealed in a worker."""
     config_path = tmp_path / "wrangler.toml"
     pyproject_path = tmp_path / "pyproject.toml"
     worker_dir = tmp_path / "src/worker"


### PR DESCRIPTION
The typing generated by `ts-to-python` package uses Python>=3.13 syntax (https://peps.python.org/pep-0696/), which is currently making the CI fail

```
FAILED tests/test_types.py::test_types - assert 'Revealed type is "js.Env"' in "src/js-stubs/__init__.pyi:109: error: Invalid syntax. Maybe you meant '==' or ':=' instead of '='?  [syntax]\nFound 1 error in 1 file (errors prevented further checking)\n"
 +  where "src/js-stubs/__init__.pyi:109: error: Invalid syntax. Maybe you meant '==' or ':=' instead of '='?  [syntax]\nFound 1 error in 1 file (errors prevented further checking)\n" = CompletedProcess(args=['uv', 'run', 'mypy'], returncode=2, stdout="src/js-stubs/__init__.pyi:109: error: Invalid synta... the workspace. Defaulting to `>=3.12`.\nDownloading mypy (11.7MiB)\n Downloaded mypy\nInstalled 7 packages in 16ms\n').stdout
```

The problematic syntax is setting the default value for the generic, which is supported only after Python 3.13.

```py
type CfProperties[HostMetadata=Any]
```

Maybe we can improve ts-to-python library to handle this case, but to unblock other pull requests, I changed the test to be only run in python 3.13, and included Python 3.13 in CI