### PR TITLE
fix: always pass string for subprocess env

### DIFF
--- a/src/pywrangler/sync.py
+++ b/src/pywrangler/sync.py
@@ -242,7 +242,7 @@ def _install_requirements_to_vendor(requirements: list[str]) -> None:
 def _log_installed_packages(venv_path: Path) -> None:
     result = run_command(
         ["uv", "pip", "list", "--format=freeze"],
-        env=os.environ | {"VIRTUAL_ENV": venv_path},
+        env=os.environ | {"VIRTUAL_ENV": str(venv_path)},
         capture_output=True,
         check=False,
     )

--- a/src/pywrangler/utils.py
+++ b/src/pywrangler/utils.py
@@ -122,7 +122,7 @@ def write_success(msg: str) -> None:
 def run_command(
     command: list[str],
     cwd: Path | None = None,
-    env: Mapping[str, str | Path] | None = None,
+    env: Mapping[str, str] | None = None,
     check: bool = True,
     capture_output: bool = False,
 ) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
Windows is not happy wiht `Path` type env variable. I fixed all other subprocess calls in #62, but added one again in #63 😓 .