### PR TITLE
feat(workers-runtime-sdk): implement HTMLRewriter SDK in Python

### DIFF
--- a/packages/cli/tests/workerd-test/sdk/tests/test_htmlrewriter.py
+++ b/packages/cli/tests/workerd-test/sdk/tests/test_htmlrewriter.py
@@ -1,10 +1,8 @@
 import asyncio
 
 import pytest
-from workers import HTMLRewriter, Response
-
 from pyodide.ffi import JsException
-from pyodide.http import AbortError
+from workers import HTMLRewriter, Response
 
 
 @pytest.mark.asyncio
@@ -318,10 +316,6 @@ async def test_proxy_cleanup_on_completion():
     text = await result.text()
     assert 'data-test="true"' in text
 
-    # Proxy destruction is deferred via waitUntil to avoid destroying them
-    # while JS HTMLRewriter is still finalizing. Yield to let it complete.
-    await asyncio.sleep(0)
-
     for proxy in proxies:
         assert is_proxy_destroyed(proxy), "Proxy should be destroyed after consumption"
 
@@ -340,9 +334,7 @@ async def test_exception_handling():
     rewriter.on("div", Handler())
     result = rewriter.transform(response)
 
-    try:
-        await result.text()
-    except Exception as e:
+    with pytest.raises(Exception, match="PythonError"):
         # Note: workerd will show the `info: uncaught exception; source = Uncaught; stack = PythonError`
         # in the log message, which is expected
-        assert "PythonError" in str(e)
+        await result.text()

--- a/packages/cli/tests/workerd-test/sdk/tests/test_htmlrewriter.py
+++ b/packages/cli/tests/workerd-test/sdk/tests/test_htmlrewriter.py
@@ -1,0 +1,348 @@
+import asyncio
+
+import pytest
+from workers import HTMLRewriter, Response
+
+from pyodide.ffi import JsException
+from pyodide.http import AbortError
+
+
+@pytest.mark.asyncio
+async def test_sync_element_handler():
+    html = "<html><body><div>Hello</div></body></html>"
+    response = Response(html, headers={"content-type": "text/html"})
+
+    class Handler:
+        def __init__(self):
+            self.called = False
+
+        def element(self, el):
+            self.called = True
+            el.setAttribute("data-modified", "true")
+
+    handler = Handler()
+    rewriter = HTMLRewriter()
+    rewriter.on("div", handler)
+    result = rewriter.transform(response)
+
+    text = await result.text()
+    assert handler.called, "Handler should have been called"
+    assert 'data-modified="true"' in text, f"Expected modified attribute in: {text}"
+
+
+@pytest.mark.asyncio
+async def test_async_element_handler():
+    html = "<html><body><div>Hello</div></body></html>"
+    response = Response(html, headers={"content-type": "text/html"})
+
+    class AsyncHandler:
+        def __init__(self):
+            self.called = False
+
+        async def element(self, el):
+            await asyncio.sleep(0.01)
+            self.called = True
+            el.setAttribute("data-async", "true")
+
+    handler = AsyncHandler()
+    rewriter = HTMLRewriter()
+    rewriter.on("div", handler)
+    result = rewriter.transform(response)
+
+    text = await result.text()
+    assert handler.called, "Async handler should have been called"
+    assert 'data-async="true"' in text, f"Expected async attribute in: {text}"
+
+
+@pytest.mark.asyncio
+async def test_document_handler():
+    html = "<!DOCTYPE html><html><body>Test</body></html>"
+    response = Response(html, headers={"content-type": "text/html"})
+
+    class DocHandler:
+        def __init__(self):
+            self.saw_doctype = False
+            self.saw_end = False
+
+        def doctype(self, doctype):
+            self.saw_doctype = True
+
+        def end(self, end):
+            self.saw_end = True
+            end.append("<!-- end -->", html=True)
+
+    handler = DocHandler()
+    rewriter = HTMLRewriter()
+    rewriter.on_document(handler)
+    result = rewriter.transform(response)
+
+    text = await result.text()
+    assert handler.saw_doctype, "Should have seen doctype"
+    assert handler.saw_end, "Should have seen end"
+    assert "<!-- end -->" in text, f"Expected appended content in: {text}"
+
+
+@pytest.mark.asyncio
+async def test_text_handler():
+    html = "<html><body><p>Hello World</p></body></html>"
+    response = Response(html, headers={"content-type": "text/html"})
+
+    class TextHandler:
+        def __init__(self):
+            self.texts = []
+
+        def text(self, text):
+            if text.text:
+                self.texts.append(text.text)
+
+    handler = TextHandler()
+    rewriter = HTMLRewriter()
+    rewriter.on("p", handler)
+    result = rewriter.transform(response)
+
+    text = await result.text()
+    assert "Hello World" in "".join(handler.texts), (
+        f"Expected text chunks to contain 'Hello World', got: {handler.texts}"
+    )
+    assert "Hello World" in text
+
+
+@pytest.mark.asyncio
+async def test_comment_handler():
+    html = "<html><body><!-- a comment --><div>Test</div></body></html>"
+    response = Response(html, headers={"content-type": "text/html"})
+
+    class CommentHandler:
+        def __init__(self):
+            self.seen_comments = []
+
+        def comments(self, comment):
+            self.seen_comments.append(comment.text)
+
+    handler = CommentHandler()
+    rewriter = HTMLRewriter()
+    rewriter.on("body", handler)
+    result = rewriter.transform(response)
+
+    await result.text()
+    assert " a comment " in handler.seen_comments, (
+        f"Expected comment text, got: {handler.seen_comments}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_combined_element_and_document_handlers():
+    html = "<!DOCTYPE html><html><body><div>Test</div></body></html>"
+    response = Response(html, headers={"content-type": "text/html"})
+
+    class ElemHandler:
+        def __init__(self):
+            self.called = False
+
+        def element(self, el):
+            self.called = True
+            el.setAttribute("data-elem", "true")
+
+    class DocHandler:
+        def __init__(self):
+            self.saw_end = False
+
+        def end(self, end):
+            self.saw_end = True
+            end.append("<!-- footer -->", html=True)
+
+    elem_handler = ElemHandler()
+    doc_handler = DocHandler()
+    rewriter = HTMLRewriter()
+    rewriter.on("div", elem_handler)
+    rewriter.on_document(doc_handler)
+    result = rewriter.transform(response)
+
+    text = await result.text()
+    assert elem_handler.called, "Element handler should have been called"
+    assert doc_handler.saw_end, "Document handler should have seen end"
+    assert 'data-elem="true"' in text
+    assert "<!-- footer -->" in text
+
+
+@pytest.mark.asyncio
+async def test_no_matching_selector():
+    html = "<html><body><div>Test</div></body></html>"
+    response = Response(html, headers={"content-type": "text/html"})
+
+    class Handler:
+        def __init__(self):
+            self.called = False
+
+        def element(self, el):
+            self.called = True
+
+    handler = Handler()
+    rewriter = HTMLRewriter()
+    rewriter.on("nonexistent", handler)
+    result = rewriter.transform(response)
+
+    text = await result.text()
+    assert not handler.called, "Handler should not have been called"
+    assert "Test" in text, "Content should pass through unchanged"
+
+
+@pytest.mark.asyncio
+async def test_chained_api():
+    html = "<html><body><div>D</div><span>S</span></body></html>"
+    response = Response(html, headers={"content-type": "text/html"})
+
+    class H1:
+        def element(self, el):
+            el.setAttribute("data-h1", "true")
+
+    class H2:
+        def element(self, el):
+            el.setAttribute("data-h2", "true")
+
+    result = HTMLRewriter().on("div", H1()).on("span", H2()).transform(response)
+    text = await result.text()
+    assert 'data-h1="true"' in text
+    assert 'data-h2="true"' in text
+
+
+@pytest.mark.asyncio
+async def test_multiple_handlers():
+    html = "<html><body><div>D</div><span>S</span></body></html>"
+    response = Response(html, headers={"content-type": "text/html"})
+
+    class Handler1:
+        def element(self, el):
+            el.setAttribute("data-h1", "true")
+
+    class Handler2:
+        def element(self, el):
+            el.setAttribute("data-h2", "true")
+
+    rewriter = HTMLRewriter()
+    rewriter.on("div", Handler1())
+    rewriter.on("span", Handler2())
+
+    result = rewriter.transform(response)
+    text = await result.text()
+
+    assert 'data-h1="true"' in text, f"Handler1 didn't work: {text}"
+    assert 'data-h2="true"' in text, f"Handler2 didn't work: {text}"
+
+
+@pytest.mark.asyncio
+async def test_rewriter_reuse():
+    html = "<div>Test</div>"
+
+    class Counter:
+        def __init__(self):
+            self.count = 0
+
+        def element(self, el):
+            self.count += 1
+            el.setAttribute("data-count", str(self.count))
+
+    counter = Counter()
+    rewriter = HTMLRewriter()
+    rewriter.on("div", counter)
+
+    result1 = rewriter.transform(Response(html, headers={"content-type": "text/html"}))
+    text1 = await result1.text()
+    assert 'data-count="1"' in text1, f"First transform failed: {text1}"
+    assert counter.count == 1
+
+    result2 = rewriter.transform(Response(html, headers={"content-type": "text/html"}))
+    text2 = await result2.text()
+    assert 'data-count="2"' in text2, f"Second transform failed: {text2}"
+    assert counter.count == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_cancellation():
+    html = "<html><body><div>Test</div></body></html>"
+    response = Response(html, headers={"content-type": "text/html"})
+
+    class Handler:
+        def __init__(self):
+            self.called = False
+
+        def element(self, el):
+            self.called = True
+
+    handler = Handler()
+    rewriter = HTMLRewriter()
+    rewriter.on("div", handler)
+
+    result = rewriter.transform(response)
+
+    body = result.js_object.body
+    reader = body.getReader()
+    await reader.cancel()
+
+    # After cancellation, read() returns done instead of throwing
+    data = await reader.read()
+    assert data.done
+
+
+def is_proxy_destroyed(proxy) -> bool:
+    try:
+        return not getattr(proxy, "_attr", True)
+    except JsException as e:
+        return "Object has already been destroyed" in str(e)
+
+
+@pytest.mark.asyncio
+async def test_proxy_cleanup_on_completion():
+    import pyodide_js
+
+    pyodide_js.setDebug(True)
+    html = "<html><body><div>Test</div></body></html>"
+    response = Response(html, headers={"content-type": "text/html"})
+
+    class Handler:
+        def element(self, el):
+            el.setAttribute("data-test", "true")
+
+    rewriter = HTMLRewriter()
+    rewriter.on("div", Handler())
+    result = rewriter.transform(response)
+
+    proxies = rewriter._last_handler_proxies
+    assert proxies is not None
+    # 1 method proxy (element) + 2 stream proxies (start + cancel)
+    assert len(proxies) == 3
+
+    for proxy in proxies:
+        assert not is_proxy_destroyed(proxy), "Proxy should be alive before consumption"
+
+    text = await result.text()
+    assert 'data-test="true"' in text
+
+    # Proxy destruction is deferred via waitUntil to avoid destroying them
+    # while JS HTMLRewriter is still finalizing. Yield to let it complete.
+    await asyncio.sleep(0)
+
+    for proxy in proxies:
+        assert is_proxy_destroyed(proxy), "Proxy should be destroyed after consumption"
+
+
+@pytest.mark.asyncio
+async def test_exception_handling():
+    html = "<html><body><div>Test</div></body></html>"
+    response = Response(html, headers={"content-type": "text/html"})
+
+    class Handler:
+        def element(self, el):
+            el.setAttribute("data-test", "true")
+            raise RuntimeError("Test exception")
+
+    rewriter = HTMLRewriter()
+    rewriter.on("div", Handler())
+    result = rewriter.transform(response)
+
+    try:
+        await result.text()
+    except Exception as e:
+        # Note: workerd will show the `info: uncaught exception; source = Uncaught; stack = PythonError`
+        # in the log message, which is expected
+        assert "PythonError" in str(e)

--- a/packages/runtime-sdk/src/workers/__init__.py
+++ b/packages/runtime-sdk/src/workers/__init__.py
@@ -24,6 +24,7 @@ from ._workers import (
     python_from_rpc,
     python_to_rpc,
 )
+from .htmlrewriter import HTMLRewriter
 
 __all__ = [
     "Blob",
@@ -44,6 +45,7 @@ __all__ = [
     "Response",
     "WorkerEntrypoint",
     "WorkflowEntrypoint",
+    "HTMLRewriter",
     "env",
     "fetch",
     "handler",

--- a/packages/runtime-sdk/src/workers/htmlrewriter.py
+++ b/packages/runtime-sdk/src/workers/htmlrewriter.py
@@ -99,8 +99,7 @@ class HTMLRewriter:
                 # clean up these proxies.
 
         async def cancel(reason):
-            if reader:
-                await reader.cancel(reason)
+            await reader.cancel(reason)
 
         start_proxy = create_proxy(start)
         cancel_proxy = create_proxy(cancel)

--- a/packages/runtime-sdk/src/workers/htmlrewriter.py
+++ b/packages/runtime-sdk/src/workers/htmlrewriter.py
@@ -1,0 +1,122 @@
+import js
+from js import Object
+from pyodide.ffi import JsProxy, create_proxy, to_js
+
+from ._workers import Response, _jsnull_to_none
+
+_ELEMENT_HANDLER_METHODS = ("element", "comments", "text")
+_DOCUMENT_HANDLER_METHODS = ("doctype", "comments", "text", "end")
+
+
+def _create_js_handler(
+    handler: object, method_names: tuple[str, ...], handler_proxies: list[JsProxy]
+) -> JsProxy:
+    """
+    Instead of creating a single proxy for the entire handler object,
+    create individual proxies for each method and attach them to a plain JS object.
+
+    Proxying the handler object directly causes a problem as
+    the original HTMLRewriter stores the reference to each method,
+    and handler objects may be destroyed while JS still holds references to them.
+    """
+    methods: dict[str, JsProxy] = {}
+    for name in method_names:
+        method = getattr(handler, name, None)
+        if method is not None:
+            proxy = create_proxy(method)
+            handler_proxies.append(proxy)
+            methods[name] = proxy
+    return to_js(methods, dict_converter=Object.fromEntries)
+
+
+class HTMLRewriter:
+    def __init__(self):
+        self._handlers: list[tuple] = []
+        # Testing purpose only, stores the proxies created for handlers
+        self._last_handler_proxies: list[JsProxy] | None = None
+
+    def on(self, selector: str, handlers: object) -> "HTMLRewriter":
+        self._handlers.append(("element", selector, handlers))
+        return self
+
+    def on_document(self, handlers: object) -> "HTMLRewriter":
+        self._handlers.append(("document", handlers))
+        return self
+
+    def transform(self, response: Response) -> "Response":
+        js_rewriter = js.HTMLRewriter.new()
+        handler_proxies: list[JsProxy] = []
+
+        def _destroy_proxies():
+            for proxy in handler_proxies:
+                proxy.destroy()
+
+        for handler_info in self._handlers:
+            if handler_info[0] == "element":
+                _, selector, handler = handler_info
+                js_handler = _create_js_handler(
+                    handler, _ELEMENT_HANDLER_METHODS, handler_proxies
+                )
+                js_rewriter.on(selector, js_handler)
+            else:
+                _, handler = handler_info
+                js_handler = _create_js_handler(
+                    handler, _DOCUMENT_HANDLER_METHODS, handler_proxies
+                )
+                js_rewriter.onDocument(js_handler)
+
+        self._last_handler_proxies = handler_proxies
+        transformed = js_rewriter.transform(response.js_object)
+
+        if _jsnull_to_none(transformed.body) is None:
+            _destroy_proxies()
+            return Response(transformed)
+
+        reader = transformed.body.getReader()
+
+        async def start(controller):
+            completed = False
+            try:
+                while True:
+                    result = await reader.read()
+                    if result.done:
+                        controller.close()
+                        completed = True
+                        break
+                    controller.enqueue(result.value)
+            except Exception as e:
+                controller.error(e)
+            finally:
+                if completed:
+                    # Happy path: HTMLRewriter finished processing,
+                    # safe to destroy all proxies
+                    _destroy_proxies()
+                # TODO(later):
+                # On cancel/exception the HTMLRewriter may still hold
+                # internal references to handler method proxies, so we
+                # intentionally leak them to avoid runtime errors.
+                # We should investigate if there is a way to properly
+                # clean up these proxies.
+
+        async def cancel(reason):
+            if reader:
+                await reader.cancel(reason)
+
+        start_proxy = create_proxy(start)
+        cancel_proxy = create_proxy(cancel)
+        handler_proxies.append(start_proxy)
+        handler_proxies.append(cancel_proxy)
+
+        wrapped_body = js.ReadableStream.new(
+            start=start_proxy,
+            cancel=cancel_proxy,
+        )
+
+        return Response(
+            js.Response.new(
+                wrapped_body,
+                status=transformed.status,
+                statusText=transformed.statusText,
+                headers=transformed.headers,
+            )
+        )


### PR DESCRIPTION
Implement [HTMLRewriter](https://developers.cloudflare.com/workers/runtime-apis/html-rewriter/) in Python. Original PR is https://github.com/cloudflare/workerd/pull/5945, but I modified it a bit.

The tricky part is how to clean up the handler proxies after running the transform.

- Happy path: after reading the stream succeeds, clean up the PyProxies, done.
- Unhappy path: user can cancel the stream or there can be an exception inside handling the html file
  - unfortunately, it is unclear when we can clean up the proxies as JS HTML rewriter will internally handle the timing when they should cancel the stream operation.
  - in my original PR, I created another Proxy in `_pyodide_entrypoint_helper` that forwards to identity function when the proxy is already distroyed. However, I wasn't sure if it is stable enough.
  - So for now, I just let the proxy leak when exception or cancellation happens.
  - If we have hybrid worker support later, then we should be able to handle it more properly.

While it is not 100% satisfactory, I think it is better than having no SDK as our example was already leaking proxies. WDYT?

