### PR TITLE
fix(workers-runtime-sdk): Make pth file not warn when run in native Python

### DIFF
--- a/packages/runtime-sdk/src/_workers_sdk_entropy_import_context.pth
+++ b/packages/runtime-sdk/src/_workers_sdk_entropy_import_context.pth
@@ -1,1 +1,1 @@
-import _workers_sdk_entropy_import_context
+import _workers_sdk_entropy_import_context_loader

--- a/packages/runtime-sdk/src/_workers_sdk_entropy_import_context_loader.py
+++ b/packages/runtime-sdk/src/_workers_sdk_entropy_import_context_loader.py
@@ -1,0 +1,13 @@
+"""
+Loader shim for _workers_sdk_entropy_import_context.
+
+This module is imported by the .pth file on every Python startup. The entropy
+context patches depend on the `_cloudflare` package, which only exists inside
+the workers runtime. When running outside of the workers runtime, `_cloudflare`
+is not available, so we silently skip loading the patches.
+"""
+
+import importlib.util
+
+if importlib.util.find_spec("_cloudflare") is not None:
+    import _workers_sdk_entropy_import_context  # noqa: F401


### PR DESCRIPTION
Otherwise we get spurious errors like:

```
Error processing line 1 of ...

  Traceback (most recent call last):
    File "<frozen site>", line 207, in addpackage
    File "<string>", line 1, in <module>
    File ..., line 8, in <module>
      from _cloudflare.allow_entropy import (
          allow_bad_entropy_calls,
      )
  ModuleNotFoundError: No module named '_cloudflare'

Remainder of file ignored
```

When running natively.