### PR TITLE
ci: pin contents: read on lint and tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for the two CI workflows that were inheriting org defaults:

- `lint.yml` runs `uvx pre-commit run -a`.
- `tests.yml` runs `pytest tests` across a Python 3.12/3.13 × Ubuntu/macOS matrix and verifies the `pywrangler` shim.

Neither workflow uses the GitHub API beyond the checkout step, so `contents: read` is sufficient. Matches the top-level style in `commitlint.yml`, `cla.yml`, `release.yml`, etc. YAML validated with `yaml.safe_load`.