### PR TITLE
fix(runtime-sdk): wrap DO.abort() to cleanup stale tasks before abortion

### DIFF
--- a/packages/cli/tests/test_in_workerd.py
+++ b/packages/cli/tests/test_in_workerd.py
@@ -8,6 +8,7 @@ TEST_DIR = Path(__file__).parent
 WORKERD_TESTS = TEST_DIR / "workerd-test"
 WORKERS_PY = TEST_DIR.parent
 WORKERS_RUNTIME_SDK = WORKERS_PY.parent / "runtime-sdk" / "src"
+DISK_SERVICE_NAME = "TEST_TMPDIR"
 
 
 def discover_workerd_tests():
@@ -52,7 +53,9 @@ def bundle_cache(tmp_path_factory):
 def test_in_workerd(tmp_path, test_dir, wd_test_file, pytestconfig, bundle_cache):
     color = pytestconfig.get_terminal_writer().hasmarkup
     target = tmp_path / test_dir.name
+    disk_service_dir = target / DISK_SERVICE_NAME
     shutil.copytree(test_dir, target)
+    disk_service_dir.mkdir(exist_ok=True)
     subprocess.run(
         ["uv", "run", "--with", WORKERS_PY, "pywrangler", "sync"],
         cwd=target,
@@ -87,6 +90,7 @@ def test_in_workerd(tmp_path, test_dir, wd_test_file, pytestconfig, bundle_cache
         "--experimental",
         "--python-snapshot-dir",
         ".",
+        f"-d{DISK_SERVICE_NAME}={disk_service_dir}",
         "--pyodide-bundle-disk-cache-dir",
         bundle_cache,
     ]

--- a/packages/cli/tests/workerd-test/durable-object-abort/durable-object-abort.wd-test
+++ b/packages/cli/tests/workerd-test/durable-object-abort/durable-object-abort.wd-test
@@ -1,0 +1,27 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const config :Workerd.Config = (
+  services = [
+    (name = "main", worker = .mainWorker),
+  ],
+);
+
+const mainWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker.py", pythonModule = embed "worker.py"),
+    %PYTHON_MODULES
+  ],
+  durableObjectNamespaces = [
+    (
+      className = "AbortingDurableObject",
+      uniqueKey = "210bd0cbd803ef7883a1ee9d86cce06e",
+      enableSql = true,
+    ),
+  ],
+  durableObjectStorage = (inMemory = void),
+  bindings = [
+    (name = "ABORTER", durableObjectNamespace = "AbortingDurableObject"),
+  ],
+  compatibilityDate = "2026-01-01",
+  compatibilityFlags = ["python_workers", "service_binding_extra_handlers", "enable_python_external_sdk"],
+);

--- a/packages/cli/tests/workerd-test/durable-object-abort/pyproject.toml
+++ b/packages/cli/tests/workerd-test/durable-object-abort/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "test"
+version = "0.0.0"
+requires-python = ">=3.13"
+dependencies = []

--- a/packages/cli/tests/workerd-test/durable-object-abort/worker.py
+++ b/packages/cli/tests/workerd-test/durable-object-abort/worker.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+from unittest import TestCase
+
+from workers import DurableObject, Response, WorkerEntrypoint
+
+assertRaisesRegex = TestCase().assertRaisesRegex
+
+
+class AbortingDurableObject(DurableObject):
+    def __init__(self, state, env):
+        super().__init__(state, env)
+        self.storage = state.storage
+
+    async def fetch(self, request):
+        return Response("ok")
+
+    async def do_abort(self):
+        self.ctx.abort("test abort reason")
+
+    async def ping(self):
+        return "pong"
+
+    async def get_counter(self):
+        value = await self.storage.get("counter")
+        if value is None:
+            value = 0
+
+        value += 1
+        await self.storage.put("counter", value)
+        return value
+
+
+class Default(WorkerEntrypoint):
+    async def test(self):
+        do_id = self.env.ABORTER.idFromName("abort-test")
+        obj = self.env.ABORTER.get(do_id)
+
+        response = await obj.fetch("http://foo.com/")
+        assert await response.text() == "ok"
+
+        assert await obj.ping() == "pong"
+        assert await obj.get_counter() == 1
+
+        with assertRaisesRegex(Exception, "test abort reason"):
+            await obj.do_abort()
+
+        obj2 = self.env.ABORTER.get(do_id)
+
+        assert await obj2.ping() == "pong"
+
+        response2 = await obj2.fetch("http://foo.com/")
+        assert await response2.text() == "ok"
+
+        # DO should be recreated, so the counter should be 1
+        assert await obj2.get_counter() == 1

--- a/packages/cli/tests/workerd-test/durable-object-abort/wrangler.jsonc
+++ b/packages/cli/tests/workerd-test/durable-object-abort/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+    "name": "test-worker",
+    "compatibility_date": "2026-01-01",
+    "compatibility_flags": ["python_workers"]
+}

--- a/packages/cli/tests/workerd-test/durable-object-websocket/durable-object-websocket.wd-test
+++ b/packages/cli/tests/workerd-test/durable-object-websocket/durable-object-websocket.wd-test
@@ -1,0 +1,39 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const config :Workerd.Config = (
+  services = [
+    (name = "main", worker = .mainWorker),
+    (name = "tester", worker = .testerWorker),
+    (name = "TEST_TMPDIR", disk = (writable = true)),
+  ],
+);
+
+const mainWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker.py", pythonModule = embed "worker.py"),
+    %PYTHON_MODULES
+  ],
+  durableObjectNamespaces = [
+    (
+      className = "DurableObjectWebSocket",
+      uniqueKey = "210bd0cbd803ef7883a1ee9d86cce06e",
+      enableSql = true,
+    ),
+  ],
+  durableObjectStorage = (localDisk = "TEST_TMPDIR"),
+  bindings = [
+    (name = "ns", durableObjectNamespace = "DurableObjectWebSocket"),
+  ],
+  compatibilityDate = "2026-01-01",
+  compatibilityFlags = ["python_workers", "enable_python_external_sdk"],
+);
+
+const testerWorker :Workerd.Worker = (
+  compatibilityDate = "2026-01-01",
+  modules = [
+    (name = "tester.js", esModule = embed "tester.js"),
+  ],
+  bindings = [
+    (name = "PYTHON", service = "main"),
+  ],
+);

--- a/packages/cli/tests/workerd-test/durable-object-websocket/pyproject.toml
+++ b/packages/cli/tests/workerd-test/durable-object-websocket/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "test"
+version = "0.0.0"
+requires-python = ">=3.13"
+dependencies = []

--- a/packages/cli/tests/workerd-test/durable-object-websocket/tester.js
+++ b/packages/cli/tests/workerd-test/durable-object-websocket/tester.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+export default {
+  async test(ctrl, env, ctx) {
+    const resp = await env.PYTHON.fetch('http://example.com/websocket', {
+      headers: { Upgrade: 'websocket' },
+    });
+    const ws = resp.webSocket;
+    if (!ws) {
+      throw new Error('No websocket');
+    }
+    ws.accept();
+    const messagePromise = new Promise((resolve) => {
+      ws.addEventListener('message', (msg) => {
+        resolve(msg.data);
+      });
+    });
+    ws.send('test');
+
+    const message = await messagePromise;
+    if (message !== 'hello') {
+      throw new Error(`Unexpected websocket message: ${message}`);
+    }
+    ws.close();
+  },
+};

--- a/packages/cli/tests/workerd-test/durable-object-websocket/worker.py
+++ b/packages/cli/tests/workerd-test/durable-object-websocket/worker.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2023 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+# Copied from: https://github.com/cloudflare/workerd/tree/main/src/workerd/server/tests/python/durable-object-websocket
+from js import WebSocketPair
+from workers import DurableObject, Request, Response, WorkerEntrypoint
+
+
+class DurableObjectWebSocket(DurableObject):
+    async def fetch(self, request):
+        assert isinstance(request, Request)
+        web_socket_pair = WebSocketPair.new()
+        client, server = web_socket_pair
+        self.ctx.acceptWebSocket(server)
+        return Response(None, status=101, web_socket=client)
+
+    async def webSocketMessage(self, ws, message):
+        ws.send("hello")
+
+    async def webSocketClose(self, ws, code, reason, wasClean):
+        return None
+
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        if request.method == "GET" and request.url.endswith("/websocket"):
+            upgrade_header = request.headers.get("Upgrade")
+            if upgrade_header != "websocket":
+                return Response(
+                    None,
+                    status=426,
+                    status_text="Expected Upgrade",
+                    headers={"Content-Type": "text/plain"},
+                )
+
+            # We are explicitly testing usage via `self.env` here rather than the
+            # argument to `fetch` and using `getByName` rather than `get`.
+            stub = self.env.ns.getByName("A")
+            return await stub.fetch(request)
+
+        return Response("Not found", status=404)

--- a/packages/cli/tests/workerd-test/durable-object-websocket/wrangler.jsonc
+++ b/packages/cli/tests/workerd-test/durable-object-websocket/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+    "name": "test-worker",
+    "compatibility_date": "2026-01-01",
+    "compatibility_flags": ["python_workers"]
+}

--- a/packages/cli/tests/workerd-test/durable-object/durable-object.wd-test
+++ b/packages/cli/tests/workerd-test/durable-object/durable-object.wd-test
@@ -1,0 +1,28 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const config :Workerd.Config = (
+  services = [
+    (name = "main", worker = .mainWorker),
+    (name = "TEST_TMPDIR", disk = (writable = true)),
+  ],
+);
+
+const mainWorker :Workerd.Worker = (
+  modules = [
+    (name = "worker.py", pythonModule = embed "worker.py"),
+    %PYTHON_MODULES
+  ],
+  durableObjectNamespaces = [
+    (
+      className = "DurableObjectExample",
+      uniqueKey = "210bd0cbd803ef7883a1ee9d86cce06e",
+      enableSql = true,
+    ),
+  ],
+  durableObjectStorage = (localDisk = "TEST_TMPDIR"),
+  bindings = [
+    (name = "ns", durableObjectNamespace = "DurableObjectExample"),
+  ],
+  compatibilityDate = "2026-01-01",
+  compatibilityFlags = ["python_workers", "service_binding_extra_handlers", "enable_python_external_sdk"],
+);

--- a/packages/cli/tests/workerd-test/durable-object/pyproject.toml
+++ b/packages/cli/tests/workerd-test/durable-object/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "test"
+version = "0.0.0"
+requires-python = ">=3.13"
+dependencies = []

--- a/packages/cli/tests/workerd-test/durable-object/worker.py
+++ b/packages/cli/tests/workerd-test/durable-object/worker.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2023 Cloudflare, Inc.
+# Licensed under the Apache 2.0 license found in the LICENSE file or at:
+#     https://opensource.org/licenses/Apache-2.0
+
+# Copied from: https://github.com/cloudflare/workerd/tree/main/src/workerd/server/tests/python/durable-object
+
+from asyncio import sleep
+from urllib.parse import urlparse
+
+import pyodide
+from js import Date
+from workers import DurableObject, FetchResponse, Request, Response, WorkerEntrypoint
+
+
+class MixinTest:
+    def test_mixin(self):
+        return 1234
+
+
+class DurableObjectExample(DurableObject, MixinTest):
+    def __init__(self, state, env):
+        super().__init__(state, env)
+        assert self.env is not None
+        assert self.ctx is not None
+
+        self.state = state
+        self.counter = 0
+        self.storage = state.storage
+        self.alarm_triggered = False
+
+        # Test blockConcurrencyWhile in the constructor with a Python async callback.
+        # This is a common pattern for initializing DO state.
+        async def init_callback():
+            await self.storage.put("initialized", True)
+
+        self.ctx.blockConcurrencyWhile(init_callback)
+
+    async def fetch(self, request):
+        assert isinstance(request, Request)
+
+        curr = await self.storage.getAlarm()
+        if not curr:
+            self.storage.setAlarm(Date.now() + 100)
+
+        url = urlparse(request.url)
+        if url.path == "/counter":
+            self.counter += 1
+            return Response(f"hello from python {self.counter}")
+        elif url.path == "/alarm":
+            return Response(str(self.alarm_triggered))
+        else:
+            return Response("404")
+
+    async def alarm(self, alarm_info):
+        self.alarm_triggered = True
+
+    async def no_args_method(self):
+        return "value from python"
+
+    async def args_method(self, arg):
+        return "value from python " + arg
+
+    def mutate_dict(self, my_dict):
+        my_dict["foo"] = 42
+
+    async def test_block_concurrency_while(self):
+        # Verify the constructor's blockConcurrencyWhile ran successfully
+        initialized = await self.storage.get("initialized")
+        assert initialized, f"Expected True but got {initialized}"
+
+        # Test blockConcurrencyWhile with a Python async callback that returns a value.
+        async def my_callback():
+            await self.storage.put("blocked", "yes")
+            return 42
+
+        result = await self.ctx.blockConcurrencyWhile(my_callback)
+        assert result == 42, f"Expected 42 but got {result}"
+        blocked = await self.storage.get("blocked")
+        assert blocked == "yes", f"Expected 'yes' but got {blocked}"
+
+        return True
+
+    async def test_self_call(self):
+        test_dict = {}
+        test_dict["test"] = 1
+        self.mutate_dict(test_dict)
+        assert test_dict["test"] == 1
+        assert test_dict["foo"] == 42
+        return True
+
+    def jspi_method(self, arg):
+        from pyodide.ffi import run_sync
+
+        run_sync(sleep(0.01))
+        return arg + 1
+
+
+class Default(WorkerEntrypoint):
+    async def test(self, ctrl):
+        id = self.env.ns.idFromName("A")
+        obj = self.env.ns.get(id)
+
+        first_resp = await obj.fetch("http://foo.com/counter")
+        first_resp_data = await first_resp.text()
+        assert first_resp_data == "hello from python 1"
+
+        second_resp = await obj.fetch("http://foo.com/counter")
+        second_resp_data = await second_resp.text()
+        assert second_resp_data == "hello from python 2"
+
+        no_arg_resp = await obj.no_args_method()
+        assert no_arg_resp == "value from python"
+
+        arg_resp = await obj.args_method("test")
+        assert arg_resp == "value from python test"
+
+        assert await obj.test_block_concurrency_while()
+
+        assert await obj.test_self_call()
+
+        if pyodide.__version__ != "0.26.0a2":
+            res = await obj.jspi_method(9)
+            assert res == 10
+
+        # Verify that a mixin method can be called via RPC.
+        assert await obj.test_mixin() == 1234
+
+        # Verify that DO fetch is wrapped.
+        third_resp = await obj.fetch("http://foo.com/counter")
+        assert isinstance(third_resp, FetchResponse)
+        third_resp_data = await third_resp.text()
+        assert third_resp_data == "hello from python 3"
+
+        # Wait for alarm to get triggered.
+        for _ in range(20):
+            await sleep(0.2)
+            resp = await obj.fetch("http://foo.com/alarm")
+
+            alarm_triggered = await resp.text() == "True"
+            if alarm_triggered:
+                break
+        else:
+            raise AssertionError("Alarm never triggered")

--- a/packages/cli/tests/workerd-test/durable-object/wrangler.jsonc
+++ b/packages/cli/tests/workerd-test/durable-object/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+    "name": "test-worker",
+    "compatibility_date": "2026-01-01",
+    "compatibility_flags": ["python_workers"]
+}

--- a/packages/runtime-sdk/src/workers/_workers.py
+++ b/packages/runtime-sdk/src/workers/_workers.py
@@ -25,9 +25,6 @@ import _cloudflare_compat_flags
 # Get globals modules and import function from the entrypoint-helper
 import _pyodide_entrypoint_helper
 import js
-
-if TYPE_CHECKING:
-    from js import DurableObjectState, Env, ExecutionContext
 import pyodide.http
 from js import Object
 from pyodide import __version__ as pyodide_version
@@ -35,6 +32,7 @@ from pyodide.ffi import (
     JsBuffer,
     JsException,
     JsProxy,
+    create_once_callable,
     create_proxy,
     destroy_proxies,
     to_js,
@@ -42,6 +40,9 @@ from pyodide.ffi import (
 from pyodide.http import pyfetch
 
 from workers.workflows import NonRetryableError
+
+if TYPE_CHECKING:
+    from js import DurableObjectState, Env, ExecutionContext
 
 
 class Context(Protocol):
@@ -1064,6 +1065,39 @@ class _DurableObjectNamespaceWrapper:
         )
 
 
+class DurableObjectAbort(BaseException):
+    pass
+
+
+class DurableObjectContext:
+    def __init__(self, ctx: "DurableObjectState"):
+        self._ctx = ctx
+
+    def __getattr__(self, name):
+        result = getattr(self._ctx, name)
+        setattr(self, name, result)
+        return result
+
+    def abort(self, reason=None):
+        # DurableObjectState.abort() terminates JS execution immediately. If Python
+        # calls it synchronously while asyncio is still running the task in the event loop,
+        # V8 unwinds the stack before asyncio can run its task-exit cleanup, leaving
+        # stale task state behind for the next request.
+        #
+        # Therefore, we queue the real abort into a microtask so Python can unwind first,
+        # then raise BaseException to stop user code without being swallowed by
+        # `except Exception` handlers.
+        ctx = self._ctx
+
+        if reason is None:
+            callback = create_once_callable(lambda: ctx.abort())
+        else:
+            callback = create_once_callable(lambda: ctx.abort(reason))
+
+        js.queueMicrotask(callback)
+        raise DurableObjectAbort("Durable Object abort requested")
+
+
 class _WorkflowInstanceWrapper:
     def __init__(self, binding):
         self._binding = binding
@@ -1332,9 +1366,11 @@ def _wrap_subclass(cls):
 
     def wrapped_init(self, *args, **kwargs):
         if len(args) > 0:
-            _pyodide_entrypoint_helper.patchWaitUntil(args[0])
-        if len(args) > 1:
             args = list(args)
+            _pyodide_entrypoint_helper.patchWaitUntil(args[0])
+            if issubclass(cls, DurableObject):
+                args[0] = DurableObjectContext(args[0])
+        if len(args) > 1:
             args[1] = _EnvWrapper(args[1])
 
         original_init(self, *args, **kwargs)
@@ -1374,7 +1410,7 @@ class DurableObject:
     Base class used to define a Durable Object.
     """
 
-    ctx: "DurableObjectState"
+    ctx: "DurableObjectContext"
     env: "Env"
 
     def __init__(self, ctx: "DurableObjectState", env: "Env"):

--- a/packages/runtime-sdk/src/workers/_workers.py
+++ b/packages/runtime-sdk/src/workers/_workers.py
@@ -1365,8 +1365,8 @@ def _wrap_subclass(cls):
     original_init = cls.__init__
 
     def wrapped_init(self, *args, **kwargs):
+        args = list(args)
         if len(args) > 0:
-            args = list(args)
             _pyodide_entrypoint_helper.patchWaitUntil(args[0])
             if issubclass(cls, DurableObject):
                 args[0] = DurableObjectContext(args[0])

--- a/packages/runtime-sdk/src/workers/_workers.py
+++ b/packages/runtime-sdk/src/workers/_workers.py
@@ -1073,12 +1073,12 @@ class DurableObjectContext:
     def __init__(self, ctx: "DurableObjectState"):
         self._ctx = ctx
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str):
         result = getattr(self._ctx, name)
         setattr(self, name, result)
         return result
 
-    def abort(self, reason=None):
+    def abort(self, reason: str | None = None):
         # DurableObjectState.abort() terminates JS execution immediately. If Python
         # calls it synchronously while asyncio is still running the task in the event loop,
         # V8 unwinds the stack before asyncio can run its task-exit cleanup, leaving
@@ -1095,7 +1095,7 @@ class DurableObjectContext:
             callback = create_once_callable(lambda: ctx.abort(reason))
 
         js.queueMicrotask(callback)
-        raise DurableObjectAbort("Durable Object abort requested")
+        raise DurableObjectAbort(reason or "Durable Object abort requested")
 
 
 class _WorkflowInstanceWrapper:


### PR DESCRIPTION
Currently, calling `ctx.abort()` inside a Python Durable Object can leave the Python runtime in a corrupted asyncio state for subsequent requests.


When abort() is called, V8 terminates JS execution immediately. So when it is called inside Python event loop, V8 unwinds the JSs tack before asyncio can run its task-exit cleanup. That leaves stale task state behind, and the next request to the Durable Object can fail with:

```
RuntimeError: Cannot enter into task <PyodideTask pending name='Task-1' coro=<wrapper_func() running at introspection.py:88> wait_for=<PyodideFuture finished exception=Error: test abort reason> cb=[WebLoop._decrement_in_progress(), <FutureDoneCallback object at 0xefd408>()]> while another task <PyodideTask pending name='Task-5' coro=<wrapper_func() running at introspection.py:88> cb=[WebLoop._decrement_in_progress(), <FutureDoneCallback object at 0xb8d870>()]> is being executed.
```

As a workaround, this wraps the `abort` function so that the abortion in js side happens after the Python side unwind is finished.