### PR TITLE
chore: run workerd tests against multiple compat dates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ['3.12', '3.13']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Run tests
       working-directory: packages/cli
       run: |
-        pytest tests
+        pytest -v tests
 
     - name: Verify that pywrangler can be run globally
       run: |

--- a/packages/cli/tests/bindings-test/wrangler.jsonc
+++ b/packages/cli/tests/bindings-test/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
     "name": "bindings-test",
     "main": "src/worker.py",
-    "compatibility_date": "2026-01-01",
+    "compatibility_date": "%COMPAT_DATE",
     "compatibility_flags": ["python_workers"],
     "kv_namespaces": [
         { "binding": "KV", "id": "test-kv" }

--- a/packages/cli/tests/conftest.py
+++ b/packages/cli/tests/conftest.py
@@ -2,6 +2,7 @@
 # Each date exercises a different Python version inside the worker runtime:
 #   - "2025-09-01" -> Python 3.12 (before the 2025-09-29 cutover)
 #   - "2026-01-01" -> Python 3.13 (after the 2025-09-29 cutover)
+# TODO: use compat flag instead of compat date
 from pathlib import Path
 
 COMPAT_DATES: list[str] = ["2025-09-01", "2026-01-01"]

--- a/packages/cli/tests/conftest.py
+++ b/packages/cli/tests/conftest.py
@@ -1,0 +1,11 @@
+# Compat dates used to parametrize workerd and bindings integration tests.
+# Each date exercises a different Python version inside the worker runtime:
+#   - "2025-09-01" -> Python 3.12 (before the 2025-09-29 cutover)
+#   - "2026-01-01" -> Python 3.13 (after the 2025-09-29 cutover)
+from pathlib import Path
+
+COMPAT_DATES: list[str] = ["2025-09-01", "2026-01-01"]
+
+
+def replace_compat_date(file: Path, compat_date: str) -> None:
+    file.write_text(file.read_text().replace("%COMPAT_DATE", compat_date))

--- a/packages/cli/tests/test_bindings.py
+++ b/packages/cli/tests/test_bindings.py
@@ -18,6 +18,7 @@ from typing import Any, Literal, NotRequired, TypedDict
 
 import pytest
 import requests
+from conftest import COMPAT_DATES, replace_compat_date
 
 TEST_DIR: Path = Path(__file__).parent
 BINDINGS_TEST_DIR: Path = TEST_DIR / "bindings-test"
@@ -65,12 +66,21 @@ def _wait_for_ready(process: subprocess.Popen[str], base_url: str) -> None:
     pytest.fail(f"pywrangler dev did not become ready within {DEV_STARTUP_TIMEOUT}s")
 
 
+@pytest.fixture(scope="module", params=COMPAT_DATES)
+def compat_date(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
 @pytest.fixture(scope="module")
-def dev_server(tmp_path_factory: pytest.TempPathFactory) -> Generator[str]:
+def dev_server(
+    tmp_path_factory: pytest.TempPathFactory, compat_date: str
+) -> Generator[str]:
     """Start a pywrangler dev server on a free port and yield its base URL."""
     tmp_path = tmp_path_factory.mktemp("bindings_test")
     target = tmp_path / "bindings-test"
     shutil.copytree(BINDINGS_TEST_DIR, target)
+
+    replace_compat_date(target / "wrangler.jsonc", compat_date)
 
     subprocess.run(
         ["uv", "run", "--with", WORKERS_PY, "pywrangler", "sync"],
@@ -113,15 +123,16 @@ def dev_server(tmp_path_factory: pytest.TempPathFactory) -> Generator[str]:
         process.wait()
 
 
-_test_suite_cache: dict[str, SuiteResults] = {}
+_test_suite_cache: dict[tuple[str, str], SuiteResults] = {}
 
 
 def _get_test_results(dev_server: str, suite: str) -> SuiteResults:
-    if suite not in _test_suite_cache:
+    key = (dev_server, suite)
+    if key not in _test_suite_cache:
         resp = requests.get(f"{dev_server}/run-tests/{suite}", timeout=60)
         assert resp.ok, f"Suite '{suite}' returned {resp.status_code}: {resp.text}"
-        _test_suite_cache[suite] = resp.json()
-    return _test_suite_cache[suite]
+        _test_suite_cache[key] = resp.json()
+    return _test_suite_cache[key]
 
 
 def _make_test(suite: str, test_name: str) -> Callable:

--- a/packages/cli/tests/test_bindings.py
+++ b/packages/cli/tests/test_bindings.py
@@ -123,6 +123,7 @@ def dev_server(
         process.wait()
 
 
+# key: (dev server url, test suite)
 _test_suite_cache: dict[tuple[str, str], SuiteResults] = {}
 
 

--- a/packages/cli/tests/test_in_workerd.py
+++ b/packages/cli/tests/test_in_workerd.py
@@ -57,7 +57,9 @@ def test_in_workerd(  # noqa: PLR0913  (too-many-arguments)
     tmp_path, test_dir, wd_test_file, compat_date, pytestconfig, bundle_cache_dir
 ):
     # FIXME:
-    # pywrangler sync fails to install pyodide packages for Python 3.12 on Linux
+    # pywrangler sync fails to install pyodide packages in unittest environment + Python 3.12 + Linux
+    # This is reproducible only in the unittest environment, and doesn't happen
+    # when running the same worker manually.
     if (
         test_dir.name == "sdk"
         and compat_date < "2025-09-29"

--- a/packages/cli/tests/test_in_workerd.py
+++ b/packages/cli/tests/test_in_workerd.py
@@ -46,14 +46,14 @@ def embed(dir: Path, root: Path, level: int = 0):
 
 
 @pytest.fixture(scope="module")
-def bundle_cache(tmp_path_factory):
+def bundle_cache_dir(tmp_path_factory):
     yield tmp_path_factory.mktemp("bundle_cache")
 
 
 @pytest.mark.parametrize("compat_date", COMPAT_DATES)
 @pytest.mark.parametrize("test_dir, wd_test_file", discover_workerd_tests())
 def test_in_workerd(  # noqa: PLR0913  (too-many-arguments)
-    tmp_path, test_dir, wd_test_file, compat_date, pytestconfig, bundle_cache
+    tmp_path, test_dir, wd_test_file, compat_date, pytestconfig, bundle_cache_dir
 ):
     color = pytestconfig.get_terminal_writer().hasmarkup
     target = tmp_path / test_dir.name
@@ -100,7 +100,7 @@ def test_in_workerd(  # noqa: PLR0913  (too-many-arguments)
         ".",
         f"-d{DISK_SERVICE_NAME}={disk_service_dir}",
         "--pyodide-bundle-disk-cache-dir",
-        bundle_cache,
+        bundle_cache_dir / compat_date,
     ]
     subprocess.run(
         [

--- a/packages/cli/tests/test_in_workerd.py
+++ b/packages/cli/tests/test_in_workerd.py
@@ -3,6 +3,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from conftest import COMPAT_DATES, replace_compat_date
 
 TEST_DIR = Path(__file__).parent
 WORKERD_TESTS = TEST_DIR / "workerd-test"
@@ -49,13 +50,19 @@ def bundle_cache(tmp_path_factory):
     yield tmp_path_factory.mktemp("bundle_cache")
 
 
+@pytest.mark.parametrize("compat_date", COMPAT_DATES)
 @pytest.mark.parametrize("test_dir, wd_test_file", discover_workerd_tests())
-def test_in_workerd(tmp_path, test_dir, wd_test_file, pytestconfig, bundle_cache):
+def test_in_workerd(  # noqa: PLR0913  (too-many-arguments)
+    tmp_path, test_dir, wd_test_file, compat_date, pytestconfig, bundle_cache
+):
     color = pytestconfig.get_terminal_writer().hasmarkup
     target = tmp_path / test_dir.name
     disk_service_dir = target / DISK_SERVICE_NAME
     shutil.copytree(test_dir, target)
     disk_service_dir.mkdir(exist_ok=True)
+
+    replace_compat_date(target / "wrangler.jsonc", compat_date)
+
     subprocess.run(
         ["uv", "run", "--with", WORKERS_PY, "pywrangler", "sync"],
         cwd=target,
@@ -77,6 +84,7 @@ def test_in_workerd(tmp_path, test_dir, wd_test_file, pytestconfig, bundle_cache
         wd_config.read_text()
         .replace("%PYTHON_MODULES", python_modules)
         .replace("%COLOR", str(color).lower())
+        .replace("%COMPAT_DATE", compat_date)
     )
     subprocess.run(
         ["npm", "i", "workerd"],

--- a/packages/cli/tests/test_in_workerd.py
+++ b/packages/cli/tests/test_in_workerd.py
@@ -1,5 +1,6 @@
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -55,6 +56,15 @@ def bundle_cache_dir(tmp_path_factory):
 def test_in_workerd(  # noqa: PLR0913  (too-many-arguments)
     tmp_path, test_dir, wd_test_file, compat_date, pytestconfig, bundle_cache_dir
 ):
+    # FIXME:
+    # pywrangler sync fails to install pyodide packages for Python 3.12 on Linux
+    if (
+        test_dir.name == "sdk"
+        and compat_date < "2025-09-29"
+        and sys.platform == "linux"
+    ):
+        pytest.xfail("pywrangler sync + uv + pyodide 3.12 on Linux")
+
     color = pytestconfig.get_terminal_writer().hasmarkup
     target = tmp_path / test_dir.name
     disk_service_dir = target / DISK_SERVICE_NAME

--- a/packages/cli/tests/workerd-test/asgi/asgi.wd-test
+++ b/packages/cli/tests/workerd-test/asgi/asgi.wd-test
@@ -11,7 +11,7 @@ const unitTests :Workerd.Config = (
         bindings = [
           ( name = "SELF", service = "python-asgi" ),
         ],
-        compatibilityDate = "2026-01-01",
+        compatibilityDate = "%COMPAT_DATE",
         compatibilityFlags = ["python_workers", "enable_python_external_sdk"],
       )
     )

--- a/packages/cli/tests/workerd-test/asgi/pyproject.toml
+++ b/packages/cli/tests/workerd-test/asgi/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
 name = "test"
 version = "0.0.0"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 dependencies = ["pytest"]

--- a/packages/cli/tests/workerd-test/asgi/wrangler.jsonc
+++ b/packages/cli/tests/workerd-test/asgi/wrangler.jsonc
@@ -1,5 +1,5 @@
 {
     "name": "test-worker",
-    "compatibility_date": "2026-01-01",
+    "compatibility_date": "%COMPAT_DATE",
     "compatibility_flags": ["python_workers"]
 }

--- a/packages/cli/tests/workerd-test/durable-object-abort/durable-object-abort.wd-test
+++ b/packages/cli/tests/workerd-test/durable-object-abort/durable-object-abort.wd-test
@@ -22,6 +22,6 @@ const mainWorker :Workerd.Worker = (
   bindings = [
     (name = "ABORTER", durableObjectNamespace = "AbortingDurableObject"),
   ],
-  compatibilityDate = "2026-01-01",
+  compatibilityDate = "%COMPAT_DATE",
   compatibilityFlags = ["python_workers", "service_binding_extra_handlers", "enable_python_external_sdk"],
 );

--- a/packages/cli/tests/workerd-test/durable-object-abort/pyproject.toml
+++ b/packages/cli/tests/workerd-test/durable-object-abort/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
 name = "test"
 version = "0.0.0"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 dependencies = []

--- a/packages/cli/tests/workerd-test/durable-object-abort/wrangler.jsonc
+++ b/packages/cli/tests/workerd-test/durable-object-abort/wrangler.jsonc
@@ -1,5 +1,5 @@
 {
     "name": "test-worker",
-    "compatibility_date": "2026-01-01",
+    "compatibility_date": "%COMPAT_DATE",
     "compatibility_flags": ["python_workers"]
 }

--- a/packages/cli/tests/workerd-test/durable-object-websocket/durable-object-websocket.wd-test
+++ b/packages/cli/tests/workerd-test/durable-object-websocket/durable-object-websocket.wd-test
@@ -24,12 +24,12 @@ const mainWorker :Workerd.Worker = (
   bindings = [
     (name = "ns", durableObjectNamespace = "DurableObjectWebSocket"),
   ],
-  compatibilityDate = "2026-01-01",
+  compatibilityDate = "%COMPAT_DATE",
   compatibilityFlags = ["python_workers", "enable_python_external_sdk"],
 );
 
 const testerWorker :Workerd.Worker = (
-  compatibilityDate = "2026-01-01",
+  compatibilityDate = "%COMPAT_DATE",
   modules = [
     (name = "tester.js", esModule = embed "tester.js"),
   ],

--- a/packages/cli/tests/workerd-test/durable-object-websocket/pyproject.toml
+++ b/packages/cli/tests/workerd-test/durable-object-websocket/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
 name = "test"
 version = "0.0.0"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 dependencies = []

--- a/packages/cli/tests/workerd-test/durable-object-websocket/wrangler.jsonc
+++ b/packages/cli/tests/workerd-test/durable-object-websocket/wrangler.jsonc
@@ -1,5 +1,5 @@
 {
     "name": "test-worker",
-    "compatibility_date": "2026-01-01",
+    "compatibility_date": "%COMPAT_DATE",
     "compatibility_flags": ["python_workers"]
 }

--- a/packages/cli/tests/workerd-test/durable-object/durable-object.wd-test
+++ b/packages/cli/tests/workerd-test/durable-object/durable-object.wd-test
@@ -23,6 +23,6 @@ const mainWorker :Workerd.Worker = (
   bindings = [
     (name = "ns", durableObjectNamespace = "DurableObjectExample"),
   ],
-  compatibilityDate = "2026-01-01",
+  compatibilityDate = "%COMPAT_DATE",
   compatibilityFlags = ["python_workers", "service_binding_extra_handlers", "enable_python_external_sdk"],
 );

--- a/packages/cli/tests/workerd-test/durable-object/pyproject.toml
+++ b/packages/cli/tests/workerd-test/durable-object/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
 name = "test"
 version = "0.0.0"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 dependencies = []

--- a/packages/cli/tests/workerd-test/durable-object/wrangler.jsonc
+++ b/packages/cli/tests/workerd-test/durable-object/wrangler.jsonc
@@ -1,5 +1,5 @@
 {
     "name": "test-worker",
-    "compatibility_date": "2026-01-01",
+    "compatibility_date": "%COMPAT_DATE",
     "compatibility_flags": ["python_workers"]
 }

--- a/packages/cli/tests/workerd-test/python-rpc/pyproject.toml
+++ b/packages/cli/tests/workerd-test/python-rpc/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
 name = "test"
 version = "0.0.0"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 dependencies = []

--- a/packages/cli/tests/workerd-test/python-rpc/python-rpc.wd-test
+++ b/packages/cli/tests/workerd-test/python-rpc/python-rpc.wd-test
@@ -17,13 +17,13 @@ const pyWorker :Workerd.Worker = (
     (name = "JsRpc", service = (name = "js", entrypoint = "JsRpcTester")),
     (name = "FOO", text = "text binding"),
   ],
-  compatibilityDate = "2026-01-01",
+  compatibilityDate = "%COMPAT_DATE",
   compatibilityFlags = ["python_workers", "service_binding_extra_handlers", "enable_python_external_sdk"],
 );
 
 const jsWorker :Workerd.Worker = (
   compatibilityFlags = ["nodejs_compat"],
-  compatibilityDate = "2026-01-01",
+  compatibilityDate = "%COMPAT_DATE",
   modules = [
     (name = "worker", esModule = embed "worker.js"),
   ],

--- a/packages/cli/tests/workerd-test/python-rpc/wrangler.jsonc
+++ b/packages/cli/tests/workerd-test/python-rpc/wrangler.jsonc
@@ -1,5 +1,5 @@
 {
     "name": "test-worker",
-    "compatibility_date": "2026-01-01",
+    "compatibility_date": "%COMPAT_DATE",
     "compatibility_flags": ["python_workers"]
 }

--- a/packages/cli/tests/workerd-test/sdk/pyproject.toml
+++ b/packages/cli/tests/workerd-test/sdk/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
 name = "test"
 version = "0.0.0"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 dependencies = ["pytest", "pytest-asyncio<1.2.0"]

--- a/packages/cli/tests/workerd-test/sdk/sdk.wd-test
+++ b/packages/cli/tests/workerd-test/sdk/sdk.wd-test
@@ -12,7 +12,7 @@ const python :Workerd.Worker = (
       json = "%COLOR"
     ),
   ],
-  compatibilityDate = "2026-01-01",
+  compatibilityDate = "%COMPAT_DATE",
   compatibilityFlags = ["python_workers", "service_binding_extra_handlers", "python_request_headers_preserve_commas", "enable_python_external_sdk"],
 );
 
@@ -21,7 +21,7 @@ const server :Workerd.Worker = (
     (name = "server.py", pythonModule = embed "server.py"),
     %PYTHON_MODULES
   ],
-  compatibilityDate = "2026-01-01",
+  compatibilityDate = "%COMPAT_DATE",
   compatibilityFlags = ["python_workers", "python_request_headers_preserve_commas", "enable_python_external_sdk"],
 );
 

--- a/packages/cli/tests/workerd-test/sdk/worker.py
+++ b/packages/cli/tests/workerd-test/sdk/worker.py
@@ -5,7 +5,9 @@
 # behaviour doesn't need to strictly be held consistent. In fact it uses the JS fetch, so it's not
 # going to follow the SDK at all.
 
+import asyncio
 import os
+import sys
 from contextlib import asynccontextmanager
 from functools import wraps
 
@@ -24,6 +26,12 @@ async def noop(*args):
 # pytest-asyncio relies on these but in Pyodide < 0.29 WebLoop does not implement them
 WebLoop.shutdown_asyncgens = noop
 WebLoop.shutdown_default_executor = noop
+
+# Pyodide 0.26.0a2's _cancel_all_tasks calls task.exception() on pending tasks,
+# which raises InvalidStateError under Pyodide's WebLoop.
+# Ignore this error to prevent pytest-asyncio from crashing.
+if sys.version_info < (3, 13):
+    asyncio.runners._cancel_all_tasks = lambda loop: None  # type: ignore[attr-defined]
 
 
 @asynccontextmanager

--- a/packages/cli/tests/workerd-test/sdk/wrangler.jsonc
+++ b/packages/cli/tests/workerd-test/sdk/wrangler.jsonc
@@ -1,5 +1,5 @@
 {
     "name": "test-worker",
-    "compatibility_date": "2026-01-01",
+    "compatibility_date": "%COMPAT_DATE",
     "compatibility_flags": ["python_workers"]
 }


### PR DESCRIPTION
Runs workerd tests in multiple compat dates to ensure that we don't break older python workers by mistake.