### PR TITLE
feat: update Python 3.13 package index from Pyodide 0.28.3 to 0.29.3

### DIFF
--- a/packages/cli/src/pywrangler/utils.py
+++ b/packages/cli/src/pywrangler/utils.py
@@ -394,5 +394,5 @@ def get_pyodide_index() -> str:
         case "3.12":
             v = "0.27.7"
         case "3.13":
-            v = "0.28.3"
+            v = "0.29.3"
     return "https://index.pyodide.org/" + v

--- a/packages/cli/src/pywrangler/utils.py
+++ b/packages/cli/src/pywrangler/utils.py
@@ -390,6 +390,14 @@ def get_uv_pyodide_interp_name() -> str:
 
 
 def get_pyodide_index() -> str:
+    """
+    Get the Pyodide index URL based on the Python version.
+    This doesn't have to match the Pyodide version that Python workers use,
+    as long as they are ABI compatible.
+
+    When updating this, run scripts/compare_pyodide_index.py to see if there are missing
+    packages in the index.
+    """
     match get_python_version():
         case "3.12":
             v = "0.27.7"

--- a/scripts/compare_pyodide_index.py
+++ b/scripts/compare_pyodide_index.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Compare two Pyodide package indices and show added/removed packages.
+
+Usage:
+    python compare_pyodide_index.py 0.28.3 0.29.4
+"""
+
+import sys
+import urllib.request
+from html.parser import HTMLParser
+
+BASE_URL = "https://index.pyodide.org/"
+
+
+class AnchorTextParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.packages: set[str] = set()
+        self._in_anchor = False
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "a":
+            self._in_anchor = True
+
+    def handle_endtag(self, tag):
+        if tag == "a":
+            self._in_anchor = False
+
+    def handle_data(self, data):
+        if self._in_anchor:
+            name = data.strip()
+            if name:
+                self.packages.add(name)
+
+
+def fetch_packages(version: str) -> set[str]:
+    url = f"{BASE_URL}{version}"
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "compare-pyodide-index/1.0"}
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        html = resp.read().decode()
+    parser = AnchorTextParser()
+    parser.feed(html)
+    return parser.packages
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <old_version> <new_version>", file=sys.stderr)
+        sys.exit(1)
+
+    old_ver, new_ver = sys.argv[1], sys.argv[2]
+
+    print(f"Fetching index for {old_ver}...", file=sys.stderr)
+    old_pkgs = fetch_packages(old_ver)
+    print(f"  {len(old_pkgs)} packages", file=sys.stderr)
+
+    print(f"Fetching index for {new_ver}...", file=sys.stderr)
+    new_pkgs = fetch_packages(new_ver)
+    print(f"  {len(new_pkgs)} packages", file=sys.stderr)
+    print(file=sys.stderr)
+
+    removed = sorted(old_pkgs - new_pkgs)
+    added = sorted(new_pkgs - old_pkgs)
+
+    if removed:
+        print(f"Removed ({len(removed)}):")
+        for p in removed:
+            print(f"  - {p}")
+    else:
+        print("Removed: (none)")
+
+    print()
+
+    if added:
+        print(f"Added ({len(added)}):")
+        for p in added:
+            print(f"  + {p}")
+    else:
+        print("Added: (none)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Close #116 

Updates pyodide package index to the recent version. I also added (vibe-coded) a script that compares the package index to ensure we didn't lose any important package by accident.

```
python ./scripts/compare_pyodide_index.py 0.28.3 0.29.3
Fetching index for 0.28.3...
  273 packages
Fetching index for 0.29.3...
  296 packages

Removed: (none)

Added (23):
  + bilby-cython
  + bottleneck
  + cartopy
  + fastapi
  + fastcan
  + geopandas
  + google-crc32c
  + healpy
  + highspy
  + jsonpatch
  + jsonpointer
  + ml-dtypes
  + numpy-tests
  + pyarrow
  + pycdfpp
  + pygame-ce
  + pylimer-tools
  + pyproj
  + pyrodigal
  + python-calamine
  + starlette
  + typing-inspection
  + vrplib
```