### PR TITLE
feat: reverts #117

### DIFF
--- a/packages/cli/src/pywrangler/utils.py
+++ b/packages/cli/src/pywrangler/utils.py
@@ -402,5 +402,5 @@ def get_pyodide_index() -> str:
         case "3.12":
             v = "0.27.7"
         case "3.13":
-            v = "0.29.3"
+            v = "0.28.3"
     return "https://index.pyodide.org/" + v


### PR DESCRIPTION
This is causing issues with certain packages that depend on pydantic, like fastapi. Not reverting the script that the PR added.