### PR TITLE
feat: Implements cf accessor on Request

### DIFF
--- a/packages/cli/tests/workerd-test/sdk/tests/test_sdk.py
+++ b/packages/cli/tests/workerd-test/sdk/tests/test_sdk.py
@@ -452,6 +452,28 @@ async def test_request_unit_tests():
 
 
 @pytest.mark.asyncio
+async def test_request_cf_property():
+    # A Request constructed without cf should return None.
+    req_no_cf = Request("https://test.com")
+    assert req_no_cf.cf is None
+
+    # Construct a JS Request with a cf object and wrap it in the Python Request.
+    js_req = js.Request.new(
+        "https://test.com",
+        to_js(
+            {"cf": {"colo": "DFW", "country": "US"}},
+            dict_converter=js.Object.fromEntries,
+        ),
+    )
+    req_with_cf = Request(js_req)
+    cf = req_with_cf.cf
+    assert cf is not None
+    assert isinstance(cf, JsProxy), f"Expected JsProxy, got {type(cf).__name__}"
+    assert cf.colo == "DFW"
+    assert cf.country == "US"
+
+
+@pytest.mark.asyncio
 async def test_can_use_event_decorator():
     @response_handler
     async def handler(request):

--- a/packages/runtime-sdk/src/workers/_workers.py
+++ b/packages/runtime-sdk/src/workers/_workers.py
@@ -770,6 +770,20 @@ class Request:
         return self.js_object.bodyUsed
 
     @property
+    def cf(self) -> "JsProxy | None":
+        """
+        Cloudflare-specific properties about the incoming request
+        (IncomingRequestCfProperties).  Access fields via attribute
+        notation, for example ``request.cf.colo``.
+
+        Returns None when not present (for example, in the dashboard/playground
+        preview or for requests constructed without a ``cf`` value).
+
+        See https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties
+        """
+        return _jsnull_to_none(self.js_object.cf)
+
+    @property
     def cache(self) -> str:
         return self.js_object.cache
 


### PR DESCRIPTION
This accessor is missing, so users would instead need to use `request.js_object.cf` manually to access it, which isn't ideal.