### PR TITLE
chore: do not trigger release when only tests file are updated

### DIFF
--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -156,7 +156,7 @@ env = "GIT_COMMIT_AUTHOR"
 default = "semantic-release <semantic-release>"
 
 [tool.semantic_release.commit_parser_options]
-path_filters = ["."]
+path_filters = [".", "!tests/**"]
 scope_prefix = "cli"
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]


### PR DESCRIPTION
I often found that updating runtime-sdk triggers workers-py release, because of updating the `cli/tests` directory. This prevents it.