### PR TITLE
fix: fix ReadableStream being incorrectly wrapped by BindingWrapper

### DIFF
--- a/packages/cli/tests/bindings-test/src/test_r2.py
+++ b/packages/cli/tests/bindings-test/src/test_r2.py
@@ -375,3 +375,19 @@ async def test_none_options_list(env):
     await bucket.put("_test/none_list", "val")
     result = await bucket.list(None)
     assert len(result.objects) >= 1
+
+
+@pytest.mark.asyncio
+async def test_body_direct_to_response(env):
+    from workers import Response
+
+    bucket = env.BUCKET
+    await _cleanup_r2(bucket)
+    key = "_test/body_direct"
+    value = "stream me directly"
+    await bucket.put(key, value)
+    obj = await bucket.get(key)
+    assert obj is not None
+    resp = Response(obj.body, headers={"x-test": "ok"})
+    text = await resp.text()
+    assert text == value

--- a/packages/runtime-sdk/src/workers/_workers.py
+++ b/packages/runtime-sdk/src/workers/_workers.py
@@ -392,14 +392,18 @@ RESPONSE_ACCEPTED_TYPES = {
     "Response",
 }
 
+# JS built-in types that should NOT be wrapped in _BindingWrapper.
+# These have their own Python-side semantics (e.g. passed directly to Response())
+# and wrapping them breaks property access like `.constructor.name`.
+_JS_PASSTHROUGH_TYPES = RESPONSE_ACCEPTED_TYPES | {
+    "Headers",
+}
 
-def _is_response_accepted_type(obj) -> bool:
-    """
-    Check if the given object is an accepted type for a Response body.
-    """
+
+def _get_js_constructor_name(obj) -> str | None:
     if hasattr(obj, "constructor"):
-        return obj.constructor.name in RESPONSE_ACCEPTED_TYPES
-    return False
+        return obj.constructor.name
+    return None
 
 
 class Response(FetchResponse):
@@ -423,11 +427,9 @@ class Response(FetchResponse):
         https://developer.mozilla.org/en-US/docs/Web/API/Response/Response.
         """
         # Verify passed in types.
-        if hasattr(body, "constructor"):
-            if not _is_response_accepted_type(body):
-                raise TypeError(
-                    f"Unsupported type in Response: {body.constructor.name}"
-                )
+        js_type = _get_js_constructor_name(body)
+        if js_type not in RESPONSE_ACCEPTED_TYPES:
+            raise TypeError(f"Unsupported type in Response: {js_type}")
         elif not isinstance(body, str | FormData | bytes) and body is not None:
             raise TypeError(f"Unsupported type in Response: {type(body).__name__}")
 
@@ -1123,18 +1125,18 @@ class _BindingWrapper:
         if not isinstance(jsobj, JsProxy):
             return False
 
-        return not _is_response_accepted_type(jsobj)
+        # TODO: This allowlist approach is a workaround. The long-term fix is to
+        # add dedicated Python wrappers for these types in python_from_rpc so they
+        # never reach _BindingWrapper in the first place.
+        js_type = _get_js_constructor_name(jsobj)
+        return js_type not in _JS_PASSTHROUGH_TYPES
 
     def _convert_result(self, result):
         converted = python_from_rpc(result)
 
         # After python_from_rpc, some objects may still be JsProxy objects.
-        # For now, we wrap all of them except the ones that are already accepted as responses
-        # with the _BindingWrapper (or a subclass of it)
-        # so that accessing attributes on them will be properly converted.
-
-        # TODO: This is a bit of a hack. We should revisit when there are more
-        # bindings to support with different return types.
+        # We need to wrap them with _BindingWrapper (or a subclass of it) again
+        # to ensure that accessing attributes on them will be properly converted.
         if self._should_wrap_nested_attribute(converted):
             return self.__class__(converted)
         if isinstance(converted, list):

--- a/packages/runtime-sdk/src/workers/_workers.py
+++ b/packages/runtime-sdk/src/workers/_workers.py
@@ -428,7 +428,7 @@ class Response(FetchResponse):
         """
         # Verify passed in types.
         js_type = _get_js_constructor_name(body)
-        if js_type not in RESPONSE_ACCEPTED_TYPES:
+        if js_type and js_type not in RESPONSE_ACCEPTED_TYPES:
             raise TypeError(f"Unsupported type in Response: {js_type}")
         elif not isinstance(body, str | FormData | bytes) and body is not None:
             raise TypeError(f"Unsupported type in Response: {type(body).__name__}")

--- a/packages/runtime-sdk/src/workers/_workers.py
+++ b/packages/runtime-sdk/src/workers/_workers.py
@@ -428,8 +428,9 @@ class Response(FetchResponse):
         """
         # Verify passed in types.
         js_type = _get_js_constructor_name(body)
-        if js_type and js_type not in RESPONSE_ACCEPTED_TYPES:
-            raise TypeError(f"Unsupported type in Response: {js_type}")
+        if js_type:
+            if js_type not in RESPONSE_ACCEPTED_TYPES:
+                raise TypeError(f"Unsupported type in Response: {js_type}")
         elif not isinstance(body, str | FormData | bytes) and body is not None:
             raise TypeError(f"Unsupported type in Response: {type(body).__name__}")
 
@@ -1129,7 +1130,7 @@ class _BindingWrapper:
         # add dedicated Python wrappers for these types in python_from_rpc so they
         # never reach _BindingWrapper in the first place.
         js_type = _get_js_constructor_name(jsobj)
-        return js_type not in _JS_PASSTHROUGH_TYPES
+        return js_type and js_type not in _JS_PASSTHROUGH_TYPES
 
     def _convert_result(self, result):
         converted = python_from_rpc(result)

--- a/packages/runtime-sdk/src/workers/_workers.py
+++ b/packages/runtime-sdk/src/workers/_workers.py
@@ -393,6 +393,15 @@ RESPONSE_ACCEPTED_TYPES = {
 }
 
 
+def _is_response_accepted_type(obj) -> bool:
+    """
+    Check if the given object is an accepted type for a Response body.
+    """
+    if hasattr(obj, "constructor"):
+        return obj.constructor.name in RESPONSE_ACCEPTED_TYPES
+    return False
+
+
 class Response(FetchResponse):
     """
     This class represents the response to an HTTP request, with a similar API to that of the web
@@ -415,7 +424,7 @@ class Response(FetchResponse):
         """
         # Verify passed in types.
         if hasattr(body, "constructor"):
-            if body.constructor.name not in RESPONSE_ACCEPTED_TYPES:
+            if not _is_response_accepted_type(body):
                 raise TypeError(
                     f"Unsupported type in Response: {body.constructor.name}"
                 )
@@ -1110,20 +1119,29 @@ class _BindingWrapper:
     def __init__(self, binding):
         self._binding = binding
 
+    def _should_wrap_nested_attribute(self, jsobj) -> bool:
+        if not isinstance(jsobj, JsProxy):
+            return False
+
+        return not _is_response_accepted_type(jsobj)
+
     def _convert_result(self, result):
         converted = python_from_rpc(result)
 
         # After python_from_rpc, some objects may still be JsProxy objects.
-        # For now, we wrap all of them with the _BindingWrapper (or a subclass of it)
+        # For now, we wrap all of them except the ones that are already accepted as responses
+        # with the _BindingWrapper (or a subclass of it)
         # so that accessing attributes on them will be properly converted.
 
         # TODO: This is a bit of a hack. We should revisit when there are more
         # bindings to support with different return types.
-        if isinstance(converted, JsProxy):
+        if self._should_wrap_nested_attribute(converted):
             return self.__class__(converted)
         if isinstance(converted, list):
             return [
-                self.__class__(item) if isinstance(item, JsProxy) else item
+                self.__class__(item)
+                if self._should_wrap_nested_attribute(item)
+                else item
                 for item in converted
             ]
         return converted


### PR DESCRIPTION
This fixes a bug that the `ReadableStream` object returned from rpc call is incorrectly wrapped with `_BindingWrapper`.

In #112, I wrapped all JsProxies returned from rpc call with `_BindingWrapper`, so that nested rpc objects can be handled properly. However, this was too aggressive that it ended up wrapping objects such as `ReadableStream` with the `_BindingWrapper` as well.

This should not be not a problem normally because `_BindingWrapper` basically pass-through all the attributes and parameters. However, when we are accessing the `constructor` attribute, which is both an object and callable, we wrap it with a Python function and loose the access to its inner attributes, leading to the following error.

```
    File "introspection.py", line 88, in wrapper_func
      return python_to_rpc(await result)
                           ^^^^^^^^^^^^
    File "/session/metadata/entry.py", line 29, in fetch
      return Response(obj.body, headers={"etag": obj.httpEtag})
    File "/session/metadata/python_modules/workers/_workers.py", line 418, in __init__
      if body.constructor.name not in RESPONSE_ACCEPTED_TYPES:
         ^^^^^^^^^^^^^^^^^^^^^
  AttributeError: 'function' object has no attribute 'name'
```

This PR is a workaround, avoid wrapping JS objects that can directly passed to the Response object. In the long term, I think the proper fix is to create a Python wrapper for ReadableStream and handle it inside the `python_from_rpc` function.