### PR TITLE
fix: fix entropy patch for newer pydantic versions

### DIFF
--- a/packages/runtime-sdk/src/_workers_sdk_entropy_import_context.py
+++ b/packages/runtime-sdk/src/_workers_sdk_entropy_import_context.py
@@ -86,6 +86,10 @@ def numpy_random_mtrand_context(module):
 @register_exec_patch("pydantic_core")
 @contextmanager
 def pydantic_core_context(module):
+    if not hasattr(module, "validate_core_schema"):
+        # Newer versions of pydantic_core don't have this function
+        yield
+        return
     try:
         # Initial import needs one entropy call to initialize
         # std::collections::HashMap hash seed


### PR DESCRIPTION
Newer pydantic versions removed this function so using newer pydantic versions raises an error (e.g. in python 3.14 test envrionment)