### PR TITLE
fix: ensure self.env and top-level env uses a same class

### DIFF
--- a/packages/cli/tests/bindings-test/src/test_do.py
+++ b/packages/cli/tests/bindings-test/src/test_do.py
@@ -1,4 +1,6 @@
 import pytest
+from pyodide.ffi import JsProxy
+from workers import env as top_level_env
 
 
 async def _get_stub(env, name="test"):
@@ -166,6 +168,18 @@ async def test_rpc_echo(env):
 async def test_rpc_dict(env):
     stub = await _get_stub(env)
     result = await stub.test_rpc_dict({"key": "value"})
+    assert result["received"]["key"] == "value"
+    assert result["added"] is True
+
+
+@pytest.mark.asyncio
+async def test_rpc_dict_via_top_level_env():
+    stub = await _get_stub(top_level_env)
+    result = await stub.test_rpc_dict({"key": "value"})
+    assert not isinstance(result, JsProxy), (
+        f"top-level workers.env RPC result should be deserialized, got {type(result)}"
+    )
+    assert isinstance(result, dict)
     assert result["received"]["key"] == "value"
     assert result["added"] is True
 

--- a/packages/cli/tests/workerd-test/sdk/tests/test_sdk.py
+++ b/packages/cli/tests/workerd-test/sdk/tests/test_sdk.py
@@ -13,6 +13,7 @@ from workers import (
     env,
     fetch,
 )
+from workers._workers import _EnvWrapper
 
 # TODO: Right now the `fetch` that's available on a binding is the JS fetch.
 # We may wish to rewrite it to be the same as the `fetch` defined in
@@ -24,8 +25,8 @@ from workers import (
 
 @pytest.mark.asyncio
 async def test_can_return_custom_fetch_response():
-    assert isinstance(env, JsProxy), (
-        "Expecting the env for these tests not to be wrapped"
+    assert isinstance(env, _EnvWrapper), (
+        "Expecting the top-level env to be wrapped by the SDK"
     )
 
     @response_handler
@@ -56,7 +57,7 @@ async def test_can_modify_response():
     text = await response.text()
     assert text == "Hi there!"
     assert response.status == 201
-    assert response.headers.get("Custom-Header-That-Should-Passthrough") == "modified"
+    assert response.headers.get("custom-header-that-should-passthrough") == "modified"
 
 
 @pytest.mark.asyncio
@@ -78,7 +79,7 @@ async def test_can_use_duplicate_headers():
     text = await response.text()
     assert text == "Hi there!"
     assert (
-        response.headers.get("Custom-Header-That-Should-Passthrough")
+        response.headers.get("custom-header-that-should-passthrough")
         == "modified, another"
     )
 
@@ -100,7 +101,7 @@ async def test_can_use_fetch_opts():
     )
     text = await response.text()
     assert text == "Hi there!"
-    assert response.headers.get("Custom-Header-That-Should-Passthrough") == "true"
+    assert response.headers.get("custom-header-that-should-passthrough") == "true"
 
 
 @pytest.mark.asyncio

--- a/packages/cli/tests/workerd-test/sdk/tests/test_sdk.py
+++ b/packages/cli/tests/workerd-test/sdk/tests/test_sdk.py
@@ -57,7 +57,7 @@ async def test_can_modify_response():
     text = await response.text()
     assert text == "Hi there!"
     assert response.status == 201
-    assert response.headers.get("custom-header-that-should-passthrough") == "modified"
+    assert response.headers.get("Custom-Header-That-Should-Passthrough") == "modified"
 
 
 @pytest.mark.asyncio
@@ -79,7 +79,7 @@ async def test_can_use_duplicate_headers():
     text = await response.text()
     assert text == "Hi there!"
     assert (
-        response.headers.get("custom-header-that-should-passthrough")
+        response.headers.get("Custom-Header-That-Should-Passthrough")
         == "modified, another"
     )
 
@@ -101,7 +101,7 @@ async def test_can_use_fetch_opts():
     )
     text = await response.text()
     assert text == "Hi there!"
-    assert response.headers.get("custom-header-that-should-passthrough") == "true"
+    assert response.headers.get("Custom-Header-That-Should-Passthrough") == "true"
 
 
 @pytest.mark.asyncio

--- a/packages/runtime-sdk/src/workers/__init__.py
+++ b/packages/runtime-sdk/src/workers/__init__.py
@@ -17,6 +17,7 @@ from ._workers import (
     Response,
     WorkerEntrypoint,
     WorkflowEntrypoint,
+    _EnvWrapper,
     fetch,
     handler,
     import_from_javascript,
@@ -59,7 +60,7 @@ __all__ = [
 def __getattr__(key):
     if key == "env":
         cloudflare_workers = import_from_javascript("cloudflare:workers")
-        return cloudflare_workers.env
+        return _EnvWrapper(cloudflare_workers.env)
     if key in ("wait_until", "waitUntil"):
         cloudflare_workers = import_from_javascript("cloudflare:workers")
         return cloudflare_workers.waitUntil

--- a/packages/runtime-sdk/src/workers/_workers.py
+++ b/packages/runtime-sdk/src/workers/_workers.py
@@ -153,8 +153,45 @@ class FetchKwargs(TypedDict, total=False):
     fetcher: type[pyfetch] | None
 
 
-# TODO: Pyodide's FetchResponse.headers returns a dict[str, str] which means
-#       duplicates are lost, we should fix that so it returns a http.client.HTTPMessage
+def _js_headers_to_http_message(
+    js_headers: dict[str, str],
+):
+    # `http.client` is imported here because it costs a lot of CPU time when imported at the
+    # top-level. At least it does when we do so in our validator tests, doesn't seem to cause
+    # trouble in production. So as a workaround we do the import here.
+    #
+    # TODO(later): when dedicated snapshots are default we can move this import to the top-level.
+    import http.client
+
+    # Newer Pyodide versions already expose headers as an http.client.HTTPMessage,
+    # in which case there is nothing to convert.
+    if isinstance(js_headers, http.client.HTTPMessage):
+        return js_headers
+
+    result = http.client.HTTPMessage()
+    if not get_compat_flag("python_request_headers_preserve_commas"):
+        for key, val in js_headers:
+            result[key] = val.strip()
+
+        return result
+
+    # With the exception of Set-Cookie, duplicate headers can and are combined with a comma
+    # in the JS Headers API. We do the same when returning the headers to Python.
+    #
+    # See https://httpwg.org/specs/rfc9110.html#rfc.section.5.3.
+    set_cookie_headers = js_headers.getSetCookie()
+    if set_cookie_headers:
+        for value in set_cookie_headers:
+            result.add_header("Set-Cookie", value.strip())
+
+    for key, val in js_headers:
+        if key.lower() == "set-cookie":
+            continue
+        result.add_header(key, val.strip())
+
+    return result
+
+
 class FetchResponse(pyodide.http.FetchResponse):
     # TODO: Consider upstreaming the `body` attribute
     # TODO: Behind a compat flag make this return a native stream (StreamReader?), or perhaps
@@ -169,6 +206,10 @@ class FetchResponse(pyodide.http.FetchResponse):
     @property
     def js_object(self) -> "js.Response":
         return self.js_response
+
+    @property
+    def headers(self):
+        return _js_headers_to_http_message(self.js_object.headers)
 
     """
     Instance methods defined below.
@@ -813,36 +854,7 @@ class Request:
 
     @property
     def headers(self):
-        # This is imported here because it costs a lot of CPU time when imported at the top-level.
-        # At least it does when we do so in our validator tests, doesn't seem to cause trouble in
-        # production. So as a workaround we do the import here.
-        #
-        # TODO(later): when dedicated snapshots are default we can move this import to the top-level.
-        import http.client
-
-        result = http.client.HTTPMessage()
-        if not get_compat_flag("python_request_headers_preserve_commas"):
-            for key, val in self.js_object.headers:
-                result[key] = val.strip()
-
-            return result
-
-        # With the exception of Set-Cookie, duplicate headers can and are combined with a comma
-        # in the JS Headers API. We do the same when returning the headers to Python.
-        #
-        # See https://httpwg.org/specs/rfc9110.html#rfc.section.5.3.
-        js_headers = self.js_object.headers
-        set_cookie_headers = js_headers.getSetCookie()
-        if set_cookie_headers:
-            for value in set_cookie_headers:
-                result.add_header("Set-Cookie", value.strip())
-
-        for key, val in js_headers:
-            if key.lower() == "set-cookie":
-                continue
-            result.add_header(key, val.strip())
-
-        return result
+        return _js_headers_to_http_message(self.js_object.headers)
 
     @property
     def integrity(self) -> str:

--- a/packages/runtime-sdk/uv.lock
+++ b/packages/runtime-sdk/uv.lock
@@ -210,7 +210,7 @@ wheels = [
 
 [[package]]
 name = "workers-runtime-sdk"
-version = "1.1.2"
+version = "1.4.3"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
fixes #135 

Wrap top-level `env` with `_EnvWrapper` so that using `self.env` and top-level `env` goes through the same wrapper.