### PR TITLE
chore: add smoke test for mtls, assets, and version metadata

### DIFF
--- a/packages/cli/tests/bindings-test/public/data.json
+++ b/packages/cli/tests/bindings-test/public/data.json
@@ -1,0 +1,1 @@
+{"key": "value", "number": 42}

--- a/packages/cli/tests/bindings-test/public/hello.txt
+++ b/packages/cli/tests/bindings-test/public/hello.txt
@@ -1,0 +1,1 @@
+hello from static assets

--- a/packages/cli/tests/bindings-test/src/test_assets.py
+++ b/packages/cli/tests/bindings-test/src/test_assets.py
@@ -1,0 +1,34 @@
+import pytest
+from workers._workers import _FetcherWrapper
+
+
+@pytest.mark.asyncio
+async def test_is_fetcher_wrapper(env):
+    assert isinstance(env.ASSETS, _FetcherWrapper)
+
+
+@pytest.mark.asyncio
+async def test_fetch_text_file(env):
+    resp = await env.ASSETS.fetch("https://assets.local/hello.txt")
+    text = await resp.text()
+    assert text.strip() == "hello from static assets"
+
+
+@pytest.mark.asyncio
+async def test_fetch_json_file(env):
+    resp = await env.ASSETS.fetch("https://assets.local/data.json")
+    data = await resp.json()
+    assert data["key"] == "value"
+    assert data["number"] == 42
+
+
+@pytest.mark.asyncio
+async def test_fetch_returns_404_for_missing(env):
+    resp = await env.ASSETS.fetch("https://assets.local/nonexistent.txt")
+    assert resp.status == 404
+
+
+@pytest.mark.asyncio
+async def test_fetch_content_type(env):
+    resp = await env.ASSETS.fetch("https://assets.local/data.json")
+    assert "application/json" in resp.headers.get("content-type")

--- a/packages/cli/tests/bindings-test/src/test_mtls.py
+++ b/packages/cli/tests/bindings-test/src/test_mtls.py
@@ -1,0 +1,13 @@
+import pytest
+from workers._workers import _FetcherWrapper
+
+# cannot test mTLS locally so we just check the binding is properly wrapped
+
+@pytest.mark.asyncio
+async def test_is_fetcher_wrapper(env):
+    assert isinstance(env.MY_CERT, _FetcherWrapper)
+
+
+@pytest.mark.asyncio
+async def test_has_fetch(env):
+    assert callable(env.MY_CERT.fetch)

--- a/packages/cli/tests/bindings-test/src/test_mtls.py
+++ b/packages/cli/tests/bindings-test/src/test_mtls.py
@@ -3,6 +3,7 @@ from workers._workers import _FetcherWrapper
 
 # cannot test mTLS locally so we just check the binding is properly wrapped
 
+
 @pytest.mark.asyncio
 async def test_is_fetcher_wrapper(env):
     assert isinstance(env.MY_CERT, _FetcherWrapper)

--- a/packages/cli/tests/bindings-test/src/test_version_metadata.py
+++ b/packages/cli/tests/bindings-test/src/test_version_metadata.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_has_id(env):
+    assert isinstance(env.VERSION.id, str)
+    assert len(env.VERSION.id) > 0
+
+
+@pytest.mark.asyncio
+async def test_has_tag(env):
+    assert isinstance(env.VERSION.tag, str)
+
+
+@pytest.mark.asyncio
+async def test_has_timestamp(env):
+    assert env.VERSION.timestamp is not None

--- a/packages/cli/tests/bindings-test/wrangler.jsonc
+++ b/packages/cli/tests/bindings-test/wrangler.jsonc
@@ -41,5 +41,14 @@
     "images": { "binding": "IMAGES" },
     "ratelimits": [
         { "name": "RATE_LIMITER", "namespace_id": "1001", "simple": { "period": 60, "limit": 100 } }
-    ]
+    ],
+    "version_metadata": { "binding": "VERSION" },
+    "mtls_certificates": [
+        { "binding": "MY_CERT", "certificate_id": "00000000-0000-0000-0000-000000000000" }
+    ],
+    "assets": {
+        "directory": "./public/",
+        "binding": "ASSETS",
+        "run_worker_first": true
+    }
 }


### PR DESCRIPTION
These bindings already work. Adds tests to make sure we don't accidentally break these bindings.