### PR TITLE
chore: fix semantic_release of workers-runtime-sdk package to update uv.lock file properly

### DIFF
--- a/packages/runtime-sdk/pyproject.toml
+++ b/packages/runtime-sdk/pyproject.toml
@@ -88,7 +88,12 @@ allow_zero_version = false
 no_git_verify = false
 tag_format = "workers-runtime-sdk-v{version}"
 version_toml = ["pyproject.toml:project.version"]
-build_command = "pip install uv && uv build"
+build_command = """
+  pip install uv
+  uv lock --upgrade-package "$PACKAGE_NAME"
+  git add uv.lock
+  uv build
+"""
 
 [tool.semantic_release.branches.main]
 match = "(main|master)"


### PR DESCRIPTION
Fixes a bug in our release configuration that the automated ci is not updating the `uv.lock` file.

I copied the build_command from the workers-py package:

https://github.com/cloudflare/workers-py/blob/7c5179f7ec788c1c45f55f51cad2681a28035b0a/packages/cli/pyproject.toml#L108-L113