### PR TITLE
chore: update test for serializing Blob

### DIFF
--- a/packages/cli/tests/workerd-test/python-rpc/worker.py
+++ b/packages/cli/tests/workerd-test/python-rpc/worker.py
@@ -293,12 +293,14 @@ class Default(WorkerEntrypoint):
         py_result = await env.PythonRpc.caller(inc_func)
         assert py_result == 2
 
+        py_result = await env.PythonRpc.identity(Blob("test"))
+        assert isinstance(py_result, Blob)
+        assert await py_result.text() == "test"
+
         # Verify that sending unsupported types fails.
         data_clone_regex = "^DataCloneError"
         with assertRaisesRegex(JsException, data_clone_regex):
             await env.PythonRpc.one_arg(CustomType(42))
-        with assertRaisesRegex(JsException, data_clone_regex):
-            await env.PythonRpc.one_arg(Blob("print(42)", content_type="text/python"))
         with assertRaisesRegex(JsException, data_clone_regex):
             await env.PythonRpc.identity(complex(1.23))
         with assertRaises(TypeError):


### PR DESCRIPTION
`Blob` is now serializable (https://github.com/cloudflare/workerd/commit/51d957f003a07c328f62d8a1b2519881253e5db6)

Since this is a workerd-side change, we don't need any release but we need to update our test