### PR TITLE
fix: uuid_utils is a Rust package needs rust package import context

### DIFF
--- a/packages/runtime-sdk/src/_workers_sdk_entropy_import_context.py
+++ b/packages/runtime-sdk/src/_workers_sdk_entropy_import_context.py
@@ -25,6 +25,7 @@ class STATE:
 @register_create_patch("tiktoken._tiktoken")
 @register_exec_patch("cryptography.exceptions")
 @register_exec_patch("jiter")
+@register_exec_patch("uuid_utils._uuid_utils")
 @contextmanager
 def rust_package_context(module):
     """Rust packages need one entropy call if they create a rust hash map at


### PR DESCRIPTION
One of the two fixes needed for langchain to work.