### PR TITLE
fix(runtime-sdk): deliver client WebSocket close events to the ASGI app

### DIFF
--- a/packages/cli/tests/test_in_workerd.py
+++ b/packages/cli/tests/test_in_workerd.py
@@ -77,7 +77,10 @@ def test_in_workerd(  # noqa: PLR0913  (too-many-arguments)
     # This is reproducible only in the unittest environment, and doesn't happen
     # when running the same worker manually.
     if (
-        test_dir.name in ("sdk", "entropy-patches", "asgi")
+        (
+            test_dir.name in ("sdk", "entropy-patches")
+            or test_dir.name.startswith("asgi")
+        )
         and compat_date < "2025-09-29"
         and sys.platform == "linux"
     ):

--- a/packages/cli/tests/workerd-test/asgi-ws-disconnect/asgi-ws-disconnect.wd-test
+++ b/packages/cli/tests/workerd-test/asgi-ws-disconnect/asgi-ws-disconnect.wd-test
@@ -1,0 +1,19 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const unitTests :Workerd.Config = (
+  services = [
+    ( name = "python-asgi-ws-disconnect",
+      worker = (
+        modules = [
+          (name = "worker.py", pythonModule = embed "worker.py"),
+          %PYTHON_MODULES
+        ],
+        bindings = [
+          ( name = "SELF", service = "python-asgi-ws-disconnect" ),
+        ],
+        compatibilityDate = "%COMPAT_DATE",
+        compatibilityFlags = ["python_workers"],
+      )
+    )
+  ],
+);

--- a/packages/cli/tests/workerd-test/asgi-ws-disconnect/pyproject.toml
+++ b/packages/cli/tests/workerd-test/asgi-ws-disconnect/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "test"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = ["pytest", "pytest-asyncio<1.2.0"]

--- a/packages/cli/tests/workerd-test/asgi-ws-disconnect/tests/test_ws_disconnect.py
+++ b/packages/cli/tests/workerd-test/asgi-ws-disconnect/tests/test_ws_disconnect.py
@@ -42,6 +42,7 @@ async def _ws_connect(path):
         TIMEOUT_S,
     )
 
+
 import json
 
 

--- a/packages/cli/tests/workerd-test/asgi-ws-disconnect/tests/test_ws_disconnect.py
+++ b/packages/cli/tests/workerd-test/asgi-ws-disconnect/tests/test_ws_disconnect.py
@@ -1,0 +1,70 @@
+import asyncio
+
+import pytest
+from pyodide.ffi import create_proxy, to_js
+from workers import env
+
+TIMEOUT_S = 5
+
+# Proxies must outlive the listeners they back; keep them per-module.
+_proxies = []
+
+
+def _listen(ws, event_type):
+    """Future resolved with the first event of the given type."""
+    fut = asyncio.get_event_loop().create_future()
+
+    def callback(evt):
+        if not fut.done():
+            fut.set_result(evt)
+
+    proxy = create_proxy(callback)
+    _proxies.append(proxy)
+    ws.addEventListener(event_type, proxy)
+    return fut
+
+
+async def _ws_connect(path):
+    # Upgrade through the raw JS binding (as durable-object-websocket's
+    # tester.js does): the SDK fetch wrapper routes through pyfetch, whose
+    # implicit abort signal interferes with long-lived upgraded connections.
+    from js import Object
+
+    raw = env.SELF._binding
+    return await asyncio.wait_for(
+        raw.fetch(
+            f"http://example.com{path}",
+            to_js(
+                {"headers": {"Upgrade": "websocket"}},
+                dict_converter=Object.fromEntries,
+            ),
+        ),
+        TIMEOUT_S,
+    )
+
+import json
+
+
+async def _events():
+    response = await asyncio.wait_for(
+        env.SELF.fetch("http://example.com/ws-events"), TIMEOUT_S
+    )
+    return json.loads(await response.text())
+
+
+@pytest.mark.asyncio
+async def test_client_close_reaches_app_as_disconnect():
+    response = await _ws_connect("/ws")
+    ws = response.webSocket
+    assert ws is not None
+    ws.accept()
+    before = len(await _events())
+    ws.close(1000, "bye")
+    deadline = asyncio.get_event_loop().time() + TIMEOUT_S
+    while asyncio.get_event_loop().time() < deadline:
+        events = await _events()
+        if len(events) > before:
+            assert events[-1]["type"] == "disconnect"
+            return
+        await asyncio.sleep(0.2)
+    pytest.fail("the app never observed the client's disconnect")

--- a/packages/cli/tests/workerd-test/asgi-ws-disconnect/worker.py
+++ b/packages/cli/tests/workerd-test/asgi-ws-disconnect/worker.py
@@ -1,0 +1,69 @@
+import asyncio
+import os
+import sys
+
+import asgi
+import pytest
+from pyodide.webloop import WebLoop
+from workers import WorkerEntrypoint
+
+
+async def _noop(*args):
+    pass
+
+
+# pytest-asyncio relies on these but in Pyodide < 0.29 WebLoop does not implement them
+WebLoop.shutdown_asyncgens = _noop
+WebLoop.shutdown_default_executor = _noop
+
+# Pyodide 0.26.0a2's _cancel_all_tasks calls task.exception() on pending tasks,
+# which raises InvalidStateError under Pyodide's WebLoop.
+if sys.version_info < (3, 13):
+    asyncio.runners._cancel_all_tasks = lambda loop: None  # type: ignore[attr-defined]
+
+
+async def _drain_lifespan(receive, send):
+    message = await receive()
+    if message["type"] == "lifespan.startup":
+        await send({"type": "lifespan.startup.complete"})
+
+
+ws_events = []
+
+
+class WSWatchApp:
+    """Accepts and records the client's disconnect in ws_events."""
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            await _drain_lifespan(receive, send)
+            return
+        message = await receive()
+        assert message["type"] == "websocket.connect"
+        await send({"type": "websocket.accept"})
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.disconnect":
+                ws_events.append({"type": "disconnect", "code": message.get("code")})
+                return
+
+
+ws_app = WSWatchApp()
+
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        if (request.headers.get("upgrade") or "").lower() == "websocket":
+            return await asgi.websocket(ws_app, request)
+        import json
+
+        from workers import Response
+
+        return Response(
+            json.dumps(ws_events), headers={"content-type": "application/json"}
+        )
+
+    async def test(self):
+        os.chdir("/session/metadata/tests")
+        args = [".", "-vv"]
+        assert pytest.main(args) == 0

--- a/packages/cli/tests/workerd-test/asgi-ws-disconnect/wrangler.jsonc
+++ b/packages/cli/tests/workerd-test/asgi-ws-disconnect/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+    "name": "test-worker",
+    "compatibility_date": "%COMPAT_DATE",
+    "compatibility_flags": ["python_workers"]
+}

--- a/packages/runtime-sdk/src/asgi.py
+++ b/packages/runtime-sdk/src/asgi.py
@@ -308,7 +308,7 @@ async def process_websocket(app: Any, req: "Request | js.Request") -> js.Respons
         queue.put_nowait(msg)
 
     server.onopen = onopen
-    server.onopen = onclose
+    server.onclose = onclose
     server.onmessage = onmessage
 
     async def ws_send(got):

--- a/packages/runtime-sdk/src/asgi.py
+++ b/packages/runtime-sdk/src/asgi.py
@@ -300,7 +300,10 @@ async def process_websocket(app: Any, req: "Request | js.Request") -> js.Respons
     onopen(1)
 
     def onclose(evt):
-        msg = {"type": "websocket.close", "code": evt.code, "reason": evt.reason}
+        # Client-initiated closes surface to the app as "websocket.disconnect"
+        # per the ASGI spec ("websocket.close" is the app->server direction);
+        # frameworks raise their disconnect exceptions only on this type.
+        msg = {"type": "websocket.disconnect", "code": evt.code, "reason": evt.reason}
         queue.put_nowait(msg)
 
     def onmessage(evt):


### PR DESCRIPTION
- The close handler `onclose` was wrongly assigned to `server.onopen`
- And even with the registration fixed, the enqueued event used the type `websocket.close`, which per the [ASGI spec](https://asgi.readthedocs.io/en/latest/specs/www.html#close-send-event) is the app-to-server direction; client disconnects must arrive as `websocket.disconnect` as the [spec](https://asgi.readthedocs.io/en/latest/specs/www.html#disconnect-receive-event-ws) says.
