### PR TITLE
fix: fix function object returned from RPC to be a callable

### DIFF
--- a/packages/cli/tests/bindings-test/src/test_d1.py
+++ b/packages/cli/tests/bindings-test/src/test_d1.py
@@ -1,5 +1,6 @@
 import pytest
 from pyodide.ffi import JsException
+from workers.rpc import _BindingWrapper, _RpcStubWrapper
 
 TEST_TABLE = "_test_d1"
 TEST_TABLE_TYPES = "_test_d1_types"
@@ -35,6 +36,21 @@ async def _ensure_tables(db):
         f"CREATE TABLE IF NOT EXISTS {TEST_TABLE_BATCH} "
         f"(id INTEGER PRIMARY KEY, val TEXT)"
     )
+
+
+@pytest.mark.asyncio
+async def test_chained_statements_stay_binding_wrappers(env):
+    # A binding method returning another binding object must keep the plain
+    # binding wrapper.
+    statement = env.DB.prepare(f"SELECT 1 FROM {TEST_TABLE} WHERE name = ?")
+    assert isinstance(statement, _BindingWrapper)
+    assert not isinstance(statement, _RpcStubWrapper)
+    assert not callable(statement)
+
+    bound = statement.bind("x")
+    assert isinstance(bound, _BindingWrapper)
+    assert not isinstance(bound, _RpcStubWrapper)
+    assert not callable(bound)
 
 
 @pytest.mark.asyncio

--- a/packages/cli/tests/bindings-test/src/test_kv.py
+++ b/packages/cli/tests/bindings-test/src/test_kv.py
@@ -313,3 +313,8 @@ async def test_binding_no_len(env):
     kv = env.KV
     with pytest.raises(TypeError, match="KvNamespace.*has no len"):
         len(kv)
+
+
+@pytest.mark.asyncio
+async def test_binding_is_truthy(env):
+    assert env.KV

--- a/packages/cli/tests/workerd-test/python-rpc/worker.js
+++ b/packages/cli/tests/workerd-test/python-rpc/worker.js
@@ -25,6 +25,14 @@ export class JsRpcTester extends WorkerEntrypoint {
     assert.deepStrictEqual(req.constructor.name, 'Request');
     return req;
   }
+
+  async newCounter() {
+    let value = 0;
+    return (amount = 0) => {
+      value += amount;
+      return value;
+    };
+  }
 }
 
 export default {
@@ -73,5 +81,10 @@ export default {
     );
     assert.deepStrictEqual(py_request.method, 'POST');
     assert.equal(py_request.constructor.name, 'Request');
+
+    const counter = await env.PythonRpc.new_counter();
+    assert.strictEqual(await counter(2), 2);
+    assert.strictEqual(await counter(1), 3);
+    assert.strictEqual(await counter(-5), -2);
   },
 };

--- a/packages/cli/tests/workerd-test/python-rpc/worker.py
+++ b/packages/cli/tests/workerd-test/python-rpc/worker.py
@@ -14,6 +14,7 @@ from unittest import TestCase
 import js
 from pyodide.ffi import JsException, JsProxy, to_js
 from workers import Blob, Request, Response, WorkerEntrypoint
+from workers.rpc import _RpcStubWrapper
 
 assertRaises = TestCase().assertRaises
 assertRaisesRegex = TestCase().assertRaisesRegex
@@ -60,6 +61,16 @@ class PythonRpcTester(WorkerEntrypoint):
 
     async def caller(self, func):
         return await func()
+
+    async def new_counter(self):
+        value = 0
+
+        def increment(amount=0):
+            nonlocal value
+            value += amount
+            return value
+
+        return increment
 
     async def check_env(self):
         # Verify that the `env` supplied to the entrypoint class is wrapped.
@@ -326,3 +337,32 @@ class Default(WorkerEntrypoint):
         assert not testFuture.done()
         await sleep(0.2)
         assert testFuture.result() == 100
+
+        # Python RPC returning a function (closure)
+        counter = await env.PythonRpc.new_counter()
+        assert isinstance(counter, _RpcStubWrapper), (
+            f"expected a stub wrapper, got {type(counter).__name__}"
+        )
+        assert callable(counter)
+        assert await counter(2) == 2
+        assert await counter(1) == 3
+        assert await counter(-5) == -2
+        assert bool(env.PythonRpc), "a service binding should be truthy"
+        assert bool(counter), "a stub should be truthy"
+
+        # JS RPC returning a function (closure)
+        counter = await env.JsRpc.newCounter()
+        assert isinstance(counter, _RpcStubWrapper), (
+            f"expected a stub wrapper, got {type(counter).__name__}"
+        )
+        assert callable(counter)
+        assert await counter(2) == 2
+        assert await counter(1) == 3
+        assert await counter(-5) == -2
+
+        counter = await env.PythonRpc.new_counter()
+        for obj in [env.PythonRpc, counter]:
+            with assertRaisesRegex(TypeError, "has no len"):
+                len(obj)
+            with assertRaises(TypeError):
+                list(obj)

--- a/packages/runtime-sdk/src/workers/rpc.py
+++ b/packages/runtime-sdk/src/workers/rpc.py
@@ -286,7 +286,7 @@ class _BindingWrapper:
         js_kwargs = {k: python_to_rpc(v) for k, v in kwargs.items()}
         return js_args, js_kwargs
 
-    def _invoke(self, fn, args, kwargs):
+    def _conver_and_invoke(self, fn, args, kwargs):
         js_args, js_kwargs = self._convert_args(args, kwargs)
         result = fn(*js_args, **js_kwargs)
         if hasattr(result, "then") and callable(result.then):
@@ -304,7 +304,7 @@ class _BindingWrapper:
             return self._convert_result(attr)
 
         def wrapper(*args, **kwargs):
-            return self._invoke(attr, args, kwargs)
+            return self._conver_and_invoke(attr, args, kwargs)
 
         return wrapper
 
@@ -346,7 +346,7 @@ class _RpcStubWrapper(_BindingWrapper):
     """
 
     def __call__(self, *args, **kwargs):
-        return self._invoke(self._binding, args, kwargs)
+        return self._conver_and_invoke(self._binding, args, kwargs)
 
 
 class _FetcherWrapper(_BindingWrapper):

--- a/packages/runtime-sdk/src/workers/rpc.py
+++ b/packages/runtime-sdk/src/workers/rpc.py
@@ -255,28 +255,47 @@ class _BindingWrapper:
         js_type = _get_js_constructor_name(jsobj)
         return js_type and js_type not in _JS_PASSTHROUGH_TYPES
 
+    def _wrap_js_value(self, value):
+        """
+        Wrap JSProxy returned from RPC calls with a
+        proper wrapper class.
+        """
+        if not self._should_wrap_nested_attribute(value):
+            return value
+
+        # A function or RpcTarget returned over RPC arrives as a callable JsRpcStub.
+        # Boxing it in a wrapper that has __call__ allows it to be called.
+        if callable(value):
+            return _RpcStubWrapper(value)
+
+        return self.__class__(value)
+
     def _convert_result(self, result):
         converted = python_from_rpc(result)
 
         # After python_from_rpc, some objects may still be JsProxy objects.
         # We need to wrap them with _BindingWrapper (or a subclass of it) again
         # to ensure that accessing attributes on them will be properly converted.
-        if self._should_wrap_nested_attribute(converted):
-            return self.__class__(converted)
         if isinstance(converted, list):
-            return [
-                self.__class__(item)
-                if self._should_wrap_nested_attribute(item)
-                else item
-                for item in converted
-            ]
-        return converted
+            return [self._wrap_js_value(item) for item in converted]
+        return self._wrap_js_value(converted)
 
     @staticmethod
     def _convert_args(args, kwargs):
         js_args = [python_to_rpc(arg) for arg in args]
         js_kwargs = {k: python_to_rpc(v) for k, v in kwargs.items()}
         return js_args, js_kwargs
+
+    def _invoke(self, fn, args, kwargs):
+        js_args, js_kwargs = self._convert_args(args, kwargs)
+        result = fn(*js_args, **js_kwargs)
+        if hasattr(result, "then") and callable(result.then):
+
+            async def await_and_convert():
+                return self._convert_result(await result)
+
+            return await_and_convert()
+        return self._convert_result(result)
 
     def _getattr_helper(self, name):
         attr = getattr(self._binding, name)
@@ -285,15 +304,7 @@ class _BindingWrapper:
             return self._convert_result(attr)
 
         def wrapper(*args, **kwargs):
-            js_args, js_kwargs = self._convert_args(args, kwargs)
-            result = attr(*js_args, **js_kwargs)
-            if hasattr(result, "then") and callable(result.then):
-
-                async def await_and_convert():
-                    return self._convert_result(await result)
-
-                return await_and_convert()
-            return self._convert_result(result)
+            return self._invoke(attr, args, kwargs)
 
         return wrapper
 
@@ -314,11 +325,28 @@ class _BindingWrapper:
         for item in binding:
             yield self._convert_result(item)
 
+    def __bool__(self):
+        return self._binding is not None
+
     def __len__(self):
-        binding = self._binding
-        if not hasattr(binding, "length"):
+        length = getattr(self._binding, "length", None)
+        # RPC object always returns true for attribute lookup,
+        # so make sure it is actually a numeric length.
+        if not isinstance(length, int):
             raise TypeError(f"'{self._real_name}' object has no len()")
-        return binding.length
+        return length
+
+
+class _RpcStubWrapper(_BindingWrapper):
+    """
+    A function or RpcTarget received over RPC.
+
+    Calling is always allowed but the server will reject it
+    if the target turns out not to be callable.
+    """
+
+    def __call__(self, *args, **kwargs):
+        return self._invoke(self._binding, args, kwargs)
 
 
 class _FetcherWrapper(_BindingWrapper):


### PR DESCRIPTION
This fixes some bugs related to RPC calls, that I noticed while checking [RPC docs examples](https://developers.cloudflare.com/workers/runtime-apis/rpc/).

1. When RPC call returns a function (closure), it was not interpreted as callable.
2. calling `bool(binding)` was failing because the Python class fallbacks to `len()` call when there is no `__bool__` implemented.
