### PR TITLE
Implements FastAPI assets tests.

### DIFF
--- a/packages/cli/tests/test_fastapi.py
+++ b/packages/cli/tests/test_fastapi.py
@@ -1,0 +1,44 @@
+"""Tests for FastAPI running against a live pywrangler dev server.
+
+Python 3.12 (Pyodide 0.26.0a2) is excluded. The in-worker pytest suite drives
+async tests via ``loop.run_until_complete``, which is a no-op on Pyodide 0.26.0a2
+(no ``run_sync``/JSPI): async tests return unawaited futures and report false
+passes.
+
+Python 3.14 is excluded because pydantic_core has a circular import error on
+the 3.14 Pyodide runtime (``validate_core_schema`` not found during module init).
+"""
+
+from pathlib import Path
+
+import pytest
+from conftest import COMPAT_CONFIGS, CompatConfig, register_in_worker_suites
+
+WEB_FRAMEWORKS_DIR: Path = (
+    Path(__file__).parent / "web-frameworks-test" / "fastapi-tests"
+)
+WEB_FRAMEWORKS_SRC_DIR: Path = WEB_FRAMEWORKS_DIR / "src"
+
+
+@pytest.fixture(scope="module")
+def worker_project_dir() -> Path:
+    return WEB_FRAMEWORKS_DIR
+
+
+# Exclude Python 3.12 (Pyodide 0.26.0a2) for async tests.
+# Exclude Python 3.14 due to pydantic_core circular import error on Pyodide.
+FASTAPI_COMPAT_CONFIGS = [
+    c for c in COMPAT_CONFIGS if c.python_version not in ("3.12", "3.14")
+]
+
+
+@pytest.fixture(
+    scope="module",
+    params=FASTAPI_COMPAT_CONFIGS,
+    ids=[c.python_version for c in FASTAPI_COMPAT_CONFIGS],
+)
+def compat_config(request: pytest.FixtureRequest) -> CompatConfig:
+    return request.param
+
+
+register_in_worker_suites(globals(), WEB_FRAMEWORKS_SRC_DIR)

--- a/packages/cli/tests/web-frameworks-test/fastapi-tests/public/data.json
+++ b/packages/cli/tests/web-frameworks-test/fastapi-tests/public/data.json
@@ -1,0 +1,1 @@
+{"key": "value", "number": 42}

--- a/packages/cli/tests/web-frameworks-test/fastapi-tests/public/index.html
+++ b/packages/cli/tests/web-frameworks-test/fastapi-tests/public/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+<head><title>FastAPI Assets Test</title></head>
+<body>
+<h1>Hello from static assets</h1>
+</body>
+</html>

--- a/packages/cli/tests/web-frameworks-test/fastapi-tests/public/style.css
+++ b/packages/cli/tests/web-frameworks-test/fastapi-tests/public/style.css
@@ -1,0 +1,5 @@
+body {
+    font-family: sans-serif;
+    margin: 0;
+    padding: 20px;
+}

--- a/packages/cli/tests/web-frameworks-test/fastapi-tests/pyproject.toml
+++ b/packages/cli/tests/web-frameworks-test/fastapi-tests/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "fastapi-tests"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi",
+    "pytest",
+    "pytest-asyncio<1.2.0",
+]

--- a/packages/cli/tests/web-frameworks-test/fastapi-tests/src/_client.py
+++ b/packages/cli/tests/web-frameworks-test/fastapi-tests/src/_client.py
@@ -1,0 +1,26 @@
+import json as _json
+
+import asgi
+from workers import Request
+
+BASE_URL = "http://testserver"
+
+
+async def fetch(app, path, env=None, method="GET", headers=None, body=None):
+    request = Request(
+        f"{BASE_URL}{path}",
+        method=method,
+        headers=dict(headers or {}),
+        body=body,
+    )
+    return await asgi.fetch(app, request, env or {})
+
+
+async def read_json(response):
+    text = await response.text()
+    return _json.loads(text) if text else None
+
+
+async def get_json(app, path, **kwargs):
+    response = await fetch(app, path, **kwargs)
+    return response, await read_json(response)

--- a/packages/cli/tests/web-frameworks-test/fastapi-tests/src/conftest.py
+++ b/packages/cli/tests/web-frameworks-test/fastapi-tests/src/conftest.py
@@ -1,0 +1,9 @@
+# pyright: reportMissingImports=false
+
+import pytest
+from workers import env as _env
+
+
+@pytest.fixture
+def env():
+    return _env

--- a/packages/cli/tests/web-frameworks-test/fastapi-tests/src/test_assets.py
+++ b/packages/cli/tests/web-frameworks-test/fastapi-tests/src/test_assets.py
@@ -1,0 +1,65 @@
+"""Tests for serving static files through a FastAPI frontend route backed by Workers Assets."""
+
+import pytest
+from _client import fetch, get_json
+
+
+@pytest.mark.asyncio
+async def test_serves_index_html(fastapi_app, env):
+    """Frontend route serves index.html from Workers Assets."""
+    resp = await fetch(fastapi_app, "/index.html", env=env)
+    assert resp.status == 200
+    text = await resp.text()
+    assert "Hello from static assets" in text
+    assert "<!doctype html>" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_serves_css(fastapi_app, env):
+    """Frontend route serves CSS with correct content type."""
+    resp = await fetch(fastapi_app, "/style.css", env=env)
+    assert resp.status == 200
+    text = await resp.text()
+    assert "font-family" in text
+    content_type = resp.headers.get("content-type")
+    assert "css" in content_type
+
+
+@pytest.mark.asyncio
+async def test_serves_json(fastapi_app, env):
+    """Frontend route serves JSON file and it is parseable."""
+    resp, data = await get_json(fastapi_app, "/data.json", env=env)
+    assert resp.status == 200
+    assert data["key"] == "value"
+    assert data["number"] == 42
+
+
+@pytest.mark.asyncio
+async def test_serves_json_content_type(fastapi_app, env):
+    """Frontend route serves JSON with correct content type."""
+    resp = await fetch(fastapi_app, "/data.json", env=env)
+    assert resp.status == 200
+    assert "application/json" in resp.headers.get("content-type")
+
+
+@pytest.mark.asyncio
+async def test_missing_asset_returns_404(fastapi_app, env):
+    """Frontend route returns 404 for nonexistent static files."""
+    resp = await fetch(fastapi_app, "/nonexistent.txt", env=env)
+    assert resp.status == 404
+
+
+@pytest.mark.asyncio
+async def test_api_route_still_works(fastapi_app, env):
+    """API routes take priority over the frontend catch-all."""
+    resp, data = await get_json(fastapi_app, "/api/hello", env=env)
+    assert resp.status == 200
+    assert data["message"] == "Hello from FastAPI"
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint(fastapi_app, env):
+    """Health endpoint works through FastAPI."""
+    resp, data = await get_json(fastapi_app, "/health", env=env)
+    assert resp.status == 200
+    assert data["ok"] is True

--- a/packages/cli/tests/web-frameworks-test/fastapi-tests/src/worker.py
+++ b/packages/cli/tests/web-frameworks-test/fastapi-tests/src/worker.py
@@ -1,0 +1,142 @@
+import asyncio
+import importlib.util
+
+import asgi
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import Response as FastAPIResponse
+from pyodide.webloop import WebLoop
+from workers import Response, WorkerEntrypoint
+
+
+async def _noop(*args):
+    pass
+
+
+WebLoop.shutdown_asyncgens = _noop
+WebLoop.shutdown_default_executor = _noop
+
+app = FastAPI()
+
+
+@app.get("/api/hello")
+async def api_hello():
+    return {"message": "Hello from FastAPI"}
+
+
+@app.get("/health")
+async def health():
+    return {"ok": True}
+
+
+@app.get("/{path:path}")
+async def frontend(path: str, request: Request):
+    """Proxy static asset requests to the Workers Assets binding."""
+    env = request.scope["env"]
+    asset_url = f"https://assets.local/{path}"
+    resp = await env.ASSETS.fetch(asset_url)
+    body = await resp.bytes()
+    headers = dict(resp.headers)
+    return FastAPIResponse(content=body, status_code=resp.status, headers=headers)
+
+
+class ResultCollector:
+    def __init__(self):
+        self.results = {}
+
+    @staticmethod
+    def _key(item):
+        name = item.name
+        return name[len("test_") :] if name.startswith("test_") else name
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_makereport(self, item, call):
+        outcome = yield
+        report = outcome.get_result()
+        key = self._key(item)
+
+        if report.when == "call":
+            if report.passed:
+                self.results[key] = {"status": "passed"}
+            elif report.skipped:
+                self.results[key] = {
+                    "status": "skipped",
+                    "reason": str(report.longrepr),
+                }
+            elif report.failed:
+                excinfo = call.excinfo
+                if excinfo is not None and excinfo.errisinstance(AssertionError):
+                    self.results[key] = {
+                        "status": "failed",
+                        "error": str(excinfo.value),
+                    }
+                else:
+                    self.results[key] = {
+                        "status": "error",
+                        "error": f"{excinfo.typename}: {excinfo.value}"
+                        if excinfo is not None
+                        else "unknown error",
+                        "traceback": report.longreprtext,
+                    }
+        elif report.when in ("setup", "teardown") and report.skipped:
+            self.results[key] = {
+                "status": "skipped",
+                "reason": str(report.longrepr),
+            }
+        elif report.when in ("setup", "teardown") and report.failed:
+            self.results[key] = {
+                "status": "error",
+                "error": report.longreprtext,
+                "traceback": report.longreprtext,
+            }
+
+
+class EnvPlugin:
+    def __init__(self, env):
+        self._env = env
+
+    @pytest.fixture
+    def env(self):
+        return self._env
+
+
+class FastAPIAppPlugin:
+    @pytest.fixture
+    def fastapi_app(self):
+        return app
+
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        from urllib.parse import urlparse
+
+        path = urlparse(request.url).path
+
+        if path.startswith("/run-tests/"):
+            suite_name = path[len("/run-tests/") :]
+            return self._run_suite(suite_name)
+
+        return await asgi.fetch(app, request, self.env, self.ctx)
+
+    def _run_suite(self, suite_name):
+        module = f"test_{suite_name}"
+        if importlib.util.find_spec(module) is None:
+            return Response.json(
+                {"error": f"Unknown suite '{suite_name}' (no module '{module}')"},
+                status=404,
+            )
+
+        collector = ResultCollector()
+        saved_loop = asyncio.events._get_running_loop()
+        try:
+            pytest.main(
+                ["--pyargs", module, "-p", "no:cacheprovider"],
+                plugins=[
+                    collector,
+                    EnvPlugin(self.env),
+                    FastAPIAppPlugin(),
+                ],
+            )
+        finally:
+            asyncio.events._set_running_loop(saved_loop)
+        return Response.json(collector.results)

--- a/packages/cli/tests/web-frameworks-test/fastapi-tests/wrangler.jsonc
+++ b/packages/cli/tests/web-frameworks-test/fastapi-tests/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+    "name": "fastapi-tests",
+    "main": "src/worker.py",
+    "compatibility_date": "%COMPAT_DATE",
+    "compatibility_flags": ["python_workers"],
+    "assets": {
+        "directory": "./public/",
+        "binding": "ASSETS",
+        "run_worker_first": true
+    }
+}


### PR DESCRIPTION
A starting point for fastapi tests in this repo. Starting with some asset binding tests which approximate what FastAPI's `frontend` implements.

Python 3.14 is disabled for now due to a bug which is fixed in  https://github.com/cloudflare/workers-py/pull/153


### Test Plan

```
$ cd packages/cli
$ uv run pytest tests/test_fastapi.py -v
```