### PR TITLE
fix(runtime-sdk): deliver binary WebSocket frames as ASGI `bytes`

### DIFF
--- a/packages/runtime-sdk/src/asgi.py
+++ b/packages/runtime-sdk/src/asgi.py
@@ -294,6 +294,9 @@ async def process_websocket(app: Any, req: "Request | js.Request") -> js.Respons
 
     client, server = WebSocketPair.new().object_values()
     server.accept()
+    # Binary frames otherwise arrive as Blob (observed under wrangler dev),
+    # which cannot be read synchronously in the message callback.
+    server.binaryType = "arraybuffer"
     queue = Queue()
 
     def onopen(evt):
@@ -312,7 +315,14 @@ async def process_websocket(app: Any, req: "Request | js.Request") -> js.Respons
         queue.put_nowait(msg)
 
     def onmessage(evt):
-        msg = {"type": "websocket.receive", "text": evt.data}
+        data = evt.data
+        if isinstance(data, str):
+            msg = {"type": "websocket.receive", "text": data}
+        else:
+            # Binary frames arrive as an ArrayBuffer; the ASGI spec requires
+            # them under "bytes" (frameworks like Starlette dispatch on which
+            # key is present, so labeling them "text" breaks receive_bytes()).
+            msg = {"type": "websocket.receive", "bytes": data.to_bytes()}
         queue.put_nowait(msg)
 
     server.onopen = onopen

--- a/packages/runtime-sdk/tests/workerd-test/asgi-ws-disconnect/tests/test_ws_disconnect.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi-ws-disconnect/tests/test_ws_disconnect.py
@@ -70,3 +70,32 @@ async def test_client_close_reaches_app_as_disconnect():
             return
         await asyncio.sleep(0.2)
     pytest.fail("the app never observed the client's disconnect")
+
+
+@pytest.mark.asyncio
+async def test_text_frame_arrives_as_asgi_text():
+    response = await _ws_connect("/ws-echo")
+    ws = response.webSocket
+    assert ws is not None
+    ws.accept()
+    message = _listen(ws, "message")
+    ws.send("hello")
+    evt = await asyncio.wait_for(message, TIMEOUT_S)
+    assert evt.data == "text=hello"
+    ws.close()
+
+
+@pytest.mark.asyncio
+async def test_binary_frame_arrives_as_asgi_bytes():
+    response = await _ws_connect("/ws-echo")
+    ws = response.webSocket
+    assert ws is not None
+    ws.accept()
+    message = _listen(ws, "message")
+    payload = b"\x00\x01binary"
+    ws.send(to_js(payload))
+    evt = await asyncio.wait_for(message, TIMEOUT_S)
+    data = evt.data
+    assert not isinstance(data, str), f"delivered to the app as text: {data!r}"
+    assert data.to_bytes() == b"bytes=" + payload
+    ws.close()

--- a/packages/runtime-sdk/tests/workerd-test/asgi-ws-disconnect/tests/test_ws_disconnect.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi-ws-disconnect/tests/test_ws_disconnect.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 
 import pytest
 from pyodide.ffi import create_proxy, to_js
@@ -72,30 +73,43 @@ async def test_client_close_reaches_app_as_disconnect():
     pytest.fail("the app never observed the client's disconnect")
 
 
-@pytest.mark.asyncio
-async def test_text_frame_arrives_as_asgi_text():
-    response = await _ws_connect("/ws-echo")
+@contextlib.asynccontextmanager
+async def _ws_session(path):
+    """Accepted client socket, always closed again.
+
+    A test that raises before closing leaves the app awaiting receive(), and
+    the runtime keeps the request alive for that task, so the whole worker
+    invocation hangs instead of reporting the failure.
+    """
+    response = await _ws_connect(path)
     ws = response.webSocket
     assert ws is not None
     ws.accept()
-    message = _listen(ws, "message")
-    ws.send("hello")
-    evt = await asyncio.wait_for(message, TIMEOUT_S)
-    assert evt.data == "text=hello"
-    ws.close()
+    # Without this the payload arrives as a Blob, which cannot be read
+    # synchronously in the message callback.
+    ws.binaryType = "arraybuffer"
+    try:
+        yield ws
+    finally:
+        ws.close()
+
+
+@pytest.mark.asyncio
+async def test_text_frame_arrives_as_asgi_text():
+    async with _ws_session("/ws-echo") as ws:
+        message = _listen(ws, "message")
+        ws.send("hello")
+        evt = await asyncio.wait_for(message, TIMEOUT_S)
+        assert evt.data == "text=hello"
 
 
 @pytest.mark.asyncio
 async def test_binary_frame_arrives_as_asgi_bytes():
-    response = await _ws_connect("/ws-echo")
-    ws = response.webSocket
-    assert ws is not None
-    ws.accept()
-    message = _listen(ws, "message")
-    payload = b"\x00\x01binary"
-    ws.send(to_js(payload))
-    evt = await asyncio.wait_for(message, TIMEOUT_S)
-    data = evt.data
-    assert not isinstance(data, str), f"delivered to the app as text: {data!r}"
-    assert data.to_bytes() == b"bytes=" + payload
-    ws.close()
+    async with _ws_session("/ws-echo") as ws:
+        message = _listen(ws, "message")
+        payload = b"\x00\x01binary"
+        ws.send(to_js(payload))
+        evt = await asyncio.wait_for(message, TIMEOUT_S)
+        data = evt.data
+        assert not isinstance(data, str), f"delivered to the app as text: {data!r}"
+        assert data.to_bytes() == b"bytes=" + payload

--- a/packages/runtime-sdk/tests/workerd-test/asgi-ws-disconnect/worker.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi-ws-disconnect/worker.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import sys
+from urllib.parse import urlsplit
 
 import pytest
 from pyodide.webloop import WebLoop
@@ -49,13 +50,46 @@ class WSWatchApp:
                 return
 
 
+class WSEchoApp:
+    """Accepts and echoes each frame back tagged with the ASGI key it arrived
+    under ("bytes=" / "text=" prefix), so tests can detect frames delivered
+    under the wrong key (an untagged echo would bounce a mislabeled frame
+    opaquely and pass anyway)."""
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            await _drain_lifespan(receive, send)
+            return
+        message = await receive()
+        assert message["type"] == "websocket.connect"
+        await send({"type": "websocket.accept"})
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.disconnect":
+                return
+            if message.get("bytes") is not None:
+                await send(
+                    {"type": "websocket.send", "bytes": b"bytes=" + message["bytes"]}
+                )
+            else:
+                text = message.get("text")
+                # text is always str once frames are labeled correctly; repr()
+                # keeps a regression readable instead of timing out on a
+                # TypeError inside the app.
+                reply = "text=" + (text if isinstance(text, str) else repr(text))
+                await send({"type": "websocket.send", "text": reply})
+
+
 ws_app = WSWatchApp()
+echo_app = WSEchoApp()
 
 
 class Default(WorkerEntrypoint):
     async def fetch(self, request):
         if (request.headers.get("upgrade") or "").lower() == "websocket":
-            return await asgi.websocket(ws_app, request)
+            path = urlsplit(request.url).path
+            app = echo_app if path == "/ws-echo" else ws_app
+            return await asgi.websocket(app, request)
         import json
 
         from workers import Response


### PR DESCRIPTION
This PR takes care of the case where the WebSocket payload is binary, not text: `onmessage` wrapped every frame under the ASGI `text` key, so frameworks' `receive_bytes()` paths never fired. Binary frames are now enqueued under `bytes`, and the server socket sets `binaryType = "arraybuffer"` so the frame can be read synchronously in the message callback.

`pytest -k asgi-ws` in `packages/runtime-sdk` runs the workerd suite, which asserts that a text frame and a binary frame each arrive under the right ASGI key.