### PR TITLE
fix(runtime-sdk): send empty WebSocket frames instead of dropping them

### DIFF
--- a/packages/runtime-sdk/src/asgi.py
+++ b/packages/runtime-sdk/src/asgi.py
@@ -333,12 +333,12 @@ async def process_websocket(app: Any, req: "Request | js.Request") -> js.Respons
         if got["type"] == "websocket.send":
             b = got.get("bytes", None)
             s = got.get("text", None)
-            if b:
+            if b is not None:
                 with acquire_js_buffer(b) as jsbytes:
                     # Unlike the `Response` constructor,  server.send seems to
                     # eagerly copy the source buffer
                     server.send(jsbytes)
-            if s:
+            if s is not None:
                 server.send(s)
 
         else:

--- a/packages/runtime-sdk/tests/workerd-test/asgi-ws-disconnect/tests/test_ws_disconnect.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi-ws-disconnect/tests/test_ws_disconnect.py
@@ -26,6 +26,22 @@ def _listen(ws, event_type):
     return fut
 
 
+def _collect(ws, count):
+    """Future resolved with the payloads of the first `count` messages."""
+    fut = asyncio.get_event_loop().create_future()
+    messages = []
+
+    def callback(evt):
+        messages.append(evt.data)
+        if len(messages) == count and not fut.done():
+            fut.set_result(messages)
+
+    proxy = create_proxy(callback)
+    _proxies.append(proxy)
+    ws.addEventListener("message", proxy)
+    return fut
+
+
 async def _ws_connect(path):
     # Upgrade through the raw JS binding (as durable-object-websocket's
     # tester.js does): the SDK fetch wrapper routes through pyfetch, whose
@@ -113,3 +129,14 @@ async def test_binary_frame_arrives_as_asgi_bytes():
         data = evt.data
         assert not isinstance(data, str), f"delivered to the app as text: {data!r}"
         assert data.to_bytes() == b"bytes=" + payload
+
+
+@pytest.mark.asyncio
+async def test_empty_frames_reach_the_client():
+    async with _ws_session("/ws-empty") as ws:
+        received = _collect(ws, 3)
+        ws.send("go")
+        messages = await asyncio.wait_for(received, TIMEOUT_S)
+        assert messages[0] == ""
+        assert messages[1].to_bytes() == b""
+        assert messages[2] == "done"

--- a/packages/runtime-sdk/tests/workerd-test/asgi-ws-disconnect/worker.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi-ws-disconnect/worker.py
@@ -80,15 +80,37 @@ class WSEchoApp:
                 await send({"type": "websocket.send", "text": reply})
 
 
+class WSEmptyFrameApp:
+    """On each client frame, replies with an empty text frame, an empty binary
+    frame, and a sentinel, so a test can tell whether empty frames reach the
+    client at all."""
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            await _drain_lifespan(receive, send)
+            return
+        message = await receive()
+        assert message["type"] == "websocket.connect"
+        await send({"type": "websocket.accept"})
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.disconnect":
+                return
+            await send({"type": "websocket.send", "text": ""})
+            await send({"type": "websocket.send", "bytes": b""})
+            await send({"type": "websocket.send", "text": "done"})
+
+
 ws_app = WSWatchApp()
 echo_app = WSEchoApp()
+empty_frame_app = WSEmptyFrameApp()
 
 
 class Default(WorkerEntrypoint):
     async def fetch(self, request):
         if (request.headers.get("upgrade") or "").lower() == "websocket":
             path = urlsplit(request.url).path
-            app = echo_app if path == "/ws-echo" else ws_app
+            app = {"/ws-echo": echo_app, "/ws-empty": empty_frame_app}.get(path, ws_app)
             return await asgi.websocket(app, request)
         import json
 


### PR DESCRIPTION
Care the case where the WebSocket payload is an empty text or empty binary frame: `ws_send` tested the payload for truthiness, so `b""` and `""` were skipped and never reached the client. Both keys are now compared against `None`, which is the only value that means "not this kind of frame".

`pytest -k asgi-ws` in `packages/runtime-sdk` runs the workerd suite. The test covers the app-to-client direction, where the frames are dropped, and times out without the fix.