### PR TITLE
fix(runtime-sdk): close the WebSocket transport when the app task ends

### DIFF
--- a/packages/runtime-sdk/src/workers/asgi.py
+++ b/packages/runtime-sdk/src/workers/asgi.py
@@ -16,7 +16,7 @@ logger = logging.getLogger("asgi")
 background_tasks = set()
 
 
-def run_in_background(coro: Awaitable[Any]) -> None:
+def run_in_background(coro: Awaitable[Any]) -> Future:
     fut = ensure_future(coro)
     background_tasks.add(fut)
 
@@ -27,6 +27,7 @@ def run_in_background(coro: Awaitable[Any]) -> None:
             logger.error("Unhandled exception in background task", exc_info=exc)
 
     fut.add_done_callback(_on_done)
+    return fut
 
 
 async def close_stream_quietly(writer):
@@ -388,40 +389,33 @@ async def process_websocket(
         received = await queue.get()
         return received
 
-    # Register the task with the runtime the way process_request does:
-    # waitUntil is the platform's mechanism for extending work past the
-    # response, so the task's lifetime after the 101 is otherwise unguaranteed.
     from pyodide.ffi import create_proxy
 
     from workers import wait_until
 
-    task = create_task(
+    task = run_in_background(
         app(
             request_to_scope(req, env if env is not None else {}, ws=True),
             ws_receive,
             ws_send,
         )
     )
-    background_tasks.add(task)
+    # wait_until is JS's waitUntil, so the task crosses the boundary as a proxy,
+    # destroyed once it settles rather than left to leak.
     task_proxy = create_proxy(task)
 
-    def _on_done(finished):
-        background_tasks.discard(finished)
-        exc = finished.exception() if not finished.cancelled() else None
-        if exc is not None:
-            logger.error("Exception in ASGI WebSocket application", exc_info=exc)
+    def _close_transport(finished):
         if not app_closed:
-            # Per the ASGI spec the server closes the transport when the app
-            # task ends after accept without sending websocket.close (1011 when
-            # it failed); otherwise the client keeps a half-open connection and
-            # hangs instead of reconnecting.
+            # The app ended without closing, so a half-open connection would
+            # leave the client hanging instead of reconnecting.
+            failed = not finished.cancelled() and finished.exception() is not None
             try:
-                server.close(1011 if exc is not None else 1000, "")
+                server.close(1011 if failed else 1000, "")
             except Exception:
                 pass  # the peer may already have closed the socket
         task_proxy.destroy()
 
-    task.add_done_callback(_on_done)
+    task.add_done_callback(_close_transport)
     wait_until(task_proxy)
 
     return Response.new(None, status=101, webSocket=client)

--- a/packages/runtime-sdk/src/workers/asgi.py
+++ b/packages/runtime-sdk/src/workers/asgi.py
@@ -359,7 +359,10 @@ async def process_websocket(
     server.onclose = onclose
     server.onmessage = onmessage
 
+    app_closed = False
+
     async def ws_send(got):
+        nonlocal app_closed
         if got["type"] == "websocket.accept":
             # The Workers WebSocketPair is accepted before the upgrade response
             # is returned, so there is no deferred accept operation here.
@@ -376,6 +379,7 @@ async def process_websocket(
                 server.send(s)
             return
         if got["type"] == "websocket.close":
+            app_closed = True
             server.close(got.get("code", 1000), got.get("reason", ""))
             return
         logger.warning(" == Not implemented %s", got["type"])
@@ -384,13 +388,41 @@ async def process_websocket(
         received = await queue.get()
         return received
 
-    run_in_background(
+    # Register the task with the runtime the way process_request does:
+    # waitUntil is the platform's mechanism for extending work past the
+    # response, so the task's lifetime after the 101 is otherwise unguaranteed.
+    from pyodide.ffi import create_proxy
+
+    from workers import wait_until
+
+    task = create_task(
         app(
             request_to_scope(req, env if env is not None else {}, ws=True),
             ws_receive,
             ws_send,
         )
     )
+    background_tasks.add(task)
+    task_proxy = create_proxy(task)
+
+    def _on_done(finished):
+        background_tasks.discard(finished)
+        exc = finished.exception() if not finished.cancelled() else None
+        if exc is not None:
+            logger.error("Exception in ASGI WebSocket application", exc_info=exc)
+        if not app_closed:
+            # Per the ASGI spec the server closes the transport when the app
+            # task ends after accept without sending websocket.close (1011 when
+            # it failed); otherwise the client keeps a half-open connection and
+            # hangs instead of reconnecting.
+            try:
+                server.close(1011 if exc is not None else 1000, "")
+            except Exception:
+                pass  # the peer may already have closed the socket
+        task_proxy.destroy()
+
+    task.add_done_callback(_on_done)
+    wait_until(task_proxy)
 
     return Response.new(None, status=101, webSocket=client)
 

--- a/packages/runtime-sdk/tests/workerd-test/asgi-ws-disconnect/tests/test_ws_disconnect.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi-ws-disconnect/tests/test_ws_disconnect.py
@@ -159,3 +159,11 @@ async def test_environment_reaches_websocket_scope():
         ws.send("env")
         event = await asyncio.wait_for(message, TIMEOUT_S)
         assert event.data == "worker-environment"
+
+
+@pytest.mark.asyncio
+async def test_app_crash_closes_the_transport():
+    async with _ws_session("/ws-crash") as ws:
+        close = _listen(ws, "close")
+        evt = await asyncio.wait_for(close, TIMEOUT_S)
+        assert evt.code == 1011

--- a/packages/runtime-sdk/tests/workerd-test/asgi-ws-disconnect/worker.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi-ws-disconnect/worker.py
@@ -133,11 +133,25 @@ class WSEnvApp:
         await send({"type": "websocket.send", "text": scope["env"]["marker"]})
 
 
+class WSCrashApp:
+    """Accepts, then raises: the server must close the transport (1011)."""
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            await _drain_lifespan(receive, send)
+            return
+        message = await receive()
+        assert message["type"] == "websocket.connect"
+        await send({"type": "websocket.accept"})
+        raise RuntimeError("websocket app crashed")
+
+
 ws_app = WSWatchApp()
 echo_app = WSEchoApp()
 empty_frame_app = WSEmptyFrameApp()
 close_app = WSCloseApp()
 env_app = WSEnvApp()
+crash_app = WSCrashApp()
 
 
 class Default(WorkerEntrypoint):
@@ -152,6 +166,7 @@ class Default(WorkerEntrypoint):
                 "/ws-close": close_app,
                 "/ws-echo": echo_app,
                 "/ws-empty": empty_frame_app,
+                "/ws-crash": crash_app,
             }.get(path, ws_app)
             return await asgi.websocket(app, request)
         import json


### PR DESCRIPTION
When the ASGI app task ends after accept without sending `websocket.close`, the transport is left open, so the client keeps a half-open connection and hangs instead of reconnecting. Closing the connection once the app is done is the server's job, so the server now closes it: 1011 when the task raised, 1000 otherwise.

The task is also registered with the runtime through `wait_until`, as `process_request` already does, so its lifetime after the 101 rests on the platform contract rather than on local dev happening to keep orphan tasks alive.

`pytest -k asgi-ws` in `packages/runtime-sdk` runs the workerd suite, which asserts the client sees a 1011 close after the app crashes.