### PR TITLE
fix(runtime-sdk): preserve repeated response headers (multiple `Set-Cookie`)

### DIFF
--- a/packages/runtime-sdk/src/asgi.py
+++ b/packages/runtime-sdk/src/asgi.py
@@ -8,6 +8,7 @@ from urllib.parse import unquote
 import js
 
 from workers import Context, Request
+from workers.utils import _to_js_headers
 
 ASGI = {"spec_version": "2.0", "version": "3.0"}
 NULL_BODY_STATUSES = frozenset({101, 103, 204, 205, 304})
@@ -179,7 +180,7 @@ async def process_request(
     # TODO(later): remove this parameter after unvendoring Python SDK from workerd
     ctx: Context | None,
 ) -> js.Response:
-    from js import Object, Response, TransformStream
+    from js import Response, TransformStream
     from pyodide.ffi import create_proxy
 
     status = None
@@ -221,6 +222,8 @@ async def process_request(
         if got["type"] == "http.response.start":
             status = got["status"]
             # Like above, we need to convert byte-pairs into string explicitly.
+            # A response header name may repeat (multiple Set-Cookie), so this
+            # must stay a sequence of pairs, not a name-keyed mapping.
             headers = [(k.decode(), v.decode()) for k, v in got.get("headers", [])]
 
         elif got["type"] == "http.response.body":
@@ -243,7 +246,7 @@ async def process_request(
                 readable = transform_stream.readable
                 writer = transform_stream.writable.getWriter()
                 resp = Response.new(
-                    readable, headers=Object.fromEntries(headers), status=status
+                    readable, headers=_to_js_headers(headers), status=status
                 )
                 result.set_result(resp)
                 with acquire_js_buffer(body) as jsbytes:
@@ -252,7 +255,7 @@ async def process_request(
                 # 101/103/204/205/304 must not carry a body per the Fetch spec.
                 # https://fetch.spec.whatwg.org/#null-body-status
                 resp = Response.new(
-                    None, headers=Object.fromEntries(headers), status=status
+                    None, headers=_to_js_headers(headers), status=status
                 )
                 result.set_result(resp)
                 finished_response.set()
@@ -262,7 +265,7 @@ async def process_request(
                 buf = px.getBuffer()
                 px.destroy()
                 resp = Response.new(
-                    buf.data, headers=Object.fromEntries(headers), status=status
+                    buf.data, headers=_to_js_headers(headers), status=status
                 )
                 result.set_result(resp)
                 finished_response.set()

--- a/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
@@ -417,5 +417,7 @@ async def test_late_stream_failure_terminates_response():
 @pytest.mark.asyncio
 async def test_multiple_set_cookie_headers_survive():
     response = await env.SELF.fetch("http://example.com/multi-cookie")
-    cookies = list(response.js_object.headers.getSetCookie())
-    assert cookies == ["first=1; Path=/", "second=2; Path=/"]
+    assert response.headers.get_all("set-cookie") == [
+        "first=1; Path=/",
+        "second=2; Path=/",
+    ]

--- a/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
@@ -412,3 +412,10 @@ async def test_late_stream_failure_terminates_response():
     )
     body = await asyncio.wait_for(response.text(), timeout=5)
     assert body == "chunk-1"
+
+
+@pytest.mark.asyncio
+async def test_multiple_set_cookie_headers_survive():
+    response = await env.SELF.fetch("http://example.com/multi-cookie")
+    cookies = list(response.js_object.headers.getSetCookie())
+    assert cookies == ["first=1; Path=/", "second=2; Path=/"]

--- a/packages/runtime-sdk/tests/workerd-test/asgi/worker.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi/worker.py
@@ -233,11 +233,35 @@ class ScopeEchoApp:
         await send({"type": "http.response.body", "body": body})
 
 
+class MultiCookieApp:
+    """Sends two Set-Cookie headers; both must reach the client."""
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            return
+        await receive()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"set-cookie", b"first=1; Path=/"),
+                    (b"set-cookie", b"second=2; Path=/"),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"ok"})
+
+
 app = HeaderEchoApp()
 sse_app = SSEApp()
 streaming_app = StreamingApp()
 scope_echo_app = ScopeEchoApp()
 late_failure_stream_app = LateFailureStreamApp()
+multi_cookie_app = MultiCookieApp()
 
 example_hdr = {"Header1": "Value1", "Header2": "Value2"}
 
@@ -259,6 +283,8 @@ class Default(WorkerEntrypoint):
             return await asgi.fetch(
                 late_failure_stream_app, request, self.env, self.ctx
             )
+        elif path == "/multi-cookie":
+            return await asgi.fetch(multi_cookie_app, request, self.env, self.ctx)
 
         return await asgi.fetch(app, request, self.env, self.ctx)
 


### PR DESCRIPTION
Building a header object with `Object.fromEntries(headers)` drops repeated header contents.
For example, when a response endpoint returns the header like this,
```
Set-Cookie: session=eyJhbGciOi...; Path=/; HttpOnly; Secure
Set-Cookie: csrftoken=a8f5f167f4...; Path=/; Secure; SameSite=Lax
```

Through the current bridge, `Object.fromEntries` collapses the pair and the client receives only:
```
Set-Cookie: csrftoken=a8f5f167f4...; Path=/; Secure; SameSite=Lax
```

This PR fixes it by building the headers with the SDK's own `_to_js_headers` helper, which keeps them as a `js.Headers`.

`pytest -k asgi` in `packages/runtime-sdk` runs the workerd suite, which asserts both cookies survive the round trip.