### PR TITLE
fix(runtime-sdk): terminate the response stream when the app fails mid-stream

### DIFF
--- a/packages/runtime-sdk/src/asgi.py
+++ b/packages/runtime-sdk/src/asgi.py
@@ -28,6 +28,13 @@ def run_in_background(coro: Awaitable[Any]) -> None:
     fut.add_done_callback(_on_done)
 
 
+async def close_stream_quietly(writer):
+    try:
+        await writer.close()
+    except Exception:
+        logger.debug("Closing the response stream failed", exc_info=True)
+
+
 @contextmanager
 def acquire_js_buffer(pybuffer):
     from pyodide.ffi import create_proxy
@@ -182,6 +189,7 @@ async def process_request(
 
     # Streaming state — initialized lazily on first body chunk with more_body=True.
     writer = None
+    writer_closed = False
 
     receive_queue = Queue()
     if req.body:
@@ -208,6 +216,7 @@ async def process_request(
         nonlocal status
         nonlocal headers
         nonlocal writer
+        nonlocal writer_closed
 
         if got["type"] == "http.response.start":
             status = got["status"]
@@ -224,6 +233,7 @@ async def process_request(
                     await writer.write(jsbytes.slice())
                 if not more_body:
                     await writer.close()
+                    writer_closed = True
                     finished_response.set()
             elif more_body:
                 # First body chunk with more data coming — switch to streaming.
@@ -275,6 +285,15 @@ async def process_request(
                 # Response already sent — exception can't be propagated to the
                 # client, so log it to avoid silently swallowing errors.
                 logger.exception("Exception in ASGI application after response started")
+                finished_response.set()
+                if writer is not None and not writer_closed:
+                    # End the body so a client reading it sees the stream stop
+                    # instead of waiting forever for chunks that will never
+                    # come. Deliberately not awaited: close() settles only once
+                    # the queued chunks reach a consumer, so a response body
+                    # that nobody reads would block this task, which the
+                    # runtime is waiting on through wait_until.
+                    run_in_background(close_stream_quietly(writer))
 
     # Create task to run the application in the background
     app_task = create_proxy(create_task(run_app()))

--- a/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
@@ -399,3 +399,16 @@ async def test_scope_path_is_percent_decoded():
 async def test_scope_exposes_raw_path():
     scope = await _scope("/scope/hello%20world")
     assert scope["raw_path"] == "/scope/hello%20world"
+
+
+@pytest.mark.asyncio
+async def test_late_stream_failure_terminates_response():
+    # An app that raises after the streaming response started must terminate
+    # the stream (truncated EOF) instead of leaving the client hanging; a
+    # regression here surfaces as a timeout or workerd's hung-request
+    # cancellation instead of a clean read.
+    response = await asyncio.wait_for(
+        env.SELF.fetch("http://example.com/stream-late-failure"), timeout=5
+    )
+    body = await asyncio.wait_for(response.text(), timeout=5)
+    assert body == "chunk-1"

--- a/packages/runtime-sdk/tests/workerd-test/asgi/worker.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi/worker.py
@@ -182,6 +182,29 @@ class StreamingApp:
 # ---------------------------------------------------------------------------
 
 
+class LateFailureStreamApp:
+    """Starts a streaming response, then raises: the stream must terminate."""
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            return
+        await receive()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"application/octet-stream")],
+            }
+        )
+        await send(
+            {"type": "http.response.body", "body": b"chunk-1", "more_body": True}
+        )
+        raise RuntimeError("app failed mid-stream")
+
+
 class ScopeEchoApp:
     """Echoes selected scope fields as JSON so tests can inspect them."""
 
@@ -214,6 +237,7 @@ app = HeaderEchoApp()
 sse_app = SSEApp()
 streaming_app = StreamingApp()
 scope_echo_app = ScopeEchoApp()
+late_failure_stream_app = LateFailureStreamApp()
 
 example_hdr = {"Header1": "Value1", "Header2": "Value2"}
 
@@ -231,6 +255,10 @@ class Default(WorkerEntrypoint):
             return await asgi.fetch(streaming_app, request, self.env, self.ctx)
         elif path.startswith("/scope"):
             return await asgi.fetch(scope_echo_app, request, self.env, self.ctx)
+        elif path == "/stream-late-failure":
+            return await asgi.fetch(
+                late_failure_stream_app, request, self.env, self.ctx
+            )
 
         return await asgi.fetch(app, request, self.env, self.ctx)
 


### PR DESCRIPTION
When the app raises after a streaming response has started, the `TransformStream` writer is left open, so the client waits forever for an EOF that never arrives. This PR ends the response stream on that path, so the client sees the truncated body instead of hanging.

The close is dispatched through `run_in_background` rather than awaited, because `writer.close()` settles only once the queued chunks reach a consumer: awaiting it for a response whose body nobody reads would block the app task that the runtime waits on through `wait_until`, and the request would be cancelled as hung. A pending `receive()` is woken with `http.disconnect` at the same point.

`pytest -k asgi` in `packages/runtime-sdk` runs the workerd suite, which reads the stream to completion after the app fails mid-body.