### PR TITLE
fix(runtime-sdk): strip `accept-encoding` from the scope headers

### DIFF
--- a/packages/runtime-sdk/src/asgi.py
+++ b/packages/runtime-sdk/src/asgi.py
@@ -52,7 +52,13 @@ def request_to_scope(req, env, ws=False):
     # Support both JS and Python http.client.HTTPMessage headers.
     req_headers = req.headers.items() if isinstance(req, Request) else req.headers
 
-    headers = [(k.lower().encode(), v.encode()) for k, v in req_headers]
+    # The runtime compresses responses itself, so an app-level compression
+    # middleware seeing accept-encoding would double-compress the body.
+    headers = [
+        (k.lower().encode(), v.encode())
+        for k, v in req_headers
+        if k.lower() != "accept-encoding"
+    ]
     url = URL.new(req.url)
     assert url.protocol[-1] == ":"
     scheme = url.protocol[:-1]

--- a/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
@@ -399,3 +399,19 @@ async def test_scope_path_is_percent_decoded():
 async def test_scope_exposes_raw_path():
     scope = await _scope("/scope/hello%20world")
     assert scope["raw_path"] == "/scope/hello%20world"
+
+
+@pytest.mark.asyncio
+async def test_accept_encoding_is_not_forwarded_to_the_app():
+    response = await asyncio.wait_for(
+        env.SELF.fetch(
+            "http://example.com/header-names",
+            headers=to_js({"Accept-Encoding": "gzip", "X-Custom": "propagates"}),
+        ),
+        timeout=5,
+    )
+    scope = json.loads(await response.text())
+    # The control header proves request headers reach the app at all, so the
+    # accept-encoding assertion cannot pass vacuously.
+    assert "x-custom" in scope["header_names"]
+    assert "accept-encoding" not in scope["header_names"]

--- a/packages/runtime-sdk/tests/workerd-test/asgi/worker.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi/worker.py
@@ -182,6 +182,34 @@ class StreamingApp:
 # ---------------------------------------------------------------------------
 
 
+class HeaderNamesApp:
+    """Echoes the request header names seen in the scope as JSON."""
+
+    async def __call__(self, scope, receive, send):
+        import json
+
+        if scope["type"] == "lifespan":
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            return
+        await receive()
+        header_names = sorted({name.decode() for name, _ in scope["headers"]})
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": json.dumps({"header_names": header_names}).encode(),
+            }
+        )
+
+
 class ScopeEchoApp:
     """Echoes selected scope fields as JSON so tests can inspect them."""
 
@@ -214,6 +242,7 @@ app = HeaderEchoApp()
 sse_app = SSEApp()
 streaming_app = StreamingApp()
 scope_echo_app = ScopeEchoApp()
+header_names_app = HeaderNamesApp()
 
 example_hdr = {"Header1": "Value1", "Header2": "Value2"}
 
@@ -231,6 +260,8 @@ class Default(WorkerEntrypoint):
             return await asgi.fetch(streaming_app, request, self.env, self.ctx)
         elif path.startswith("/scope"):
             return await asgi.fetch(scope_echo_app, request, self.env, self.ctx)
+        elif path == "/header-names":
+            return await asgi.fetch(header_names_app, request, self.env, self.ctx)
 
         return await asgi.fetch(app, request, self.env, self.ctx)
 


### PR DESCRIPTION
The Workers runtime compresses responses itself, so forwarding the client's `accept-encoding` to the app lets app-level compression middleware (e.g. Starlette's `GZipMiddleware`) produce double-compressed bodies. This PR strips it from the scope.

`pytest -k asgi` in `packages/runtime-sdk` runs the workerd suite. The test sends a second custom header as a control, so the assertion cannot pass vacuously.