### PR TITLE
fix(cli): force `--color never` on the parsed `uv pip freeze` output

### DIFF
--- a/packages/cli/src/pywrangler/sync.py
+++ b/packages/cli/src/pywrangler/sync.py
@@ -287,7 +287,20 @@ def _parse_pip_freeze(result: str) -> list[str]:
 def _get_vendor_package_versions() -> list[str]:
     """Get pinned package versions from pyodide venv (e.g., ["shapely==2.0.7"])."""
     result = run_command(
-        ["uv", "pip", "freeze", "--path", str(get_vendor_modules_path())],
+        [
+            "uv",
+            "pip",
+            "freeze",
+            # This output is parsed, and FORCE_COLOR-style env vars make uv
+            # colorize even when captured. "\x1b[1mshapely\x1b[0m==2.0.7"
+            # still contains "==", so it survives _parse_pip_freeze and then
+            # trips uv's requirements parser: error: Unexpected '<ESC>',
+            # expected '-c', '-e', '-r' or the start of a requirement.
+            "--color",
+            "never",
+            "--path",
+            str(get_vendor_modules_path()),
+        ],
         env=os.environ | {"VIRTUAL_ENV": str(get_pyodide_venv_path())},
         capture_output=True,
     )

--- a/packages/cli/tests/test_version_sync.py
+++ b/packages/cli/tests/test_version_sync.py
@@ -38,6 +38,24 @@ def test_parse_pip_freeze():
     assert result == ["shapely==2.0.7", "numpy==1.26.4"]
 
 
+def test_get_vendor_package_versions_disables_color():
+    """The freeze output is parsed, so uv must not colorize it even under
+    color-forcing environments (e.g. FORCE_COLOR=1)."""
+    with (
+        patch.object(pywrangler_sync, "run_command") as mock_run,
+        patch.object(pywrangler_sync, "get_vendor_modules_path"),
+        patch.object(pywrangler_sync, "get_pyodide_venv_path"),
+    ):
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "shapely==2.0.7\n"
+
+        result = pywrangler_sync._get_vendor_package_versions()
+
+    assert result == ["shapely==2.0.7"]
+    command = mock_run.call_args[0][0]
+    assert command[:5] == ["uv", "pip", "freeze", "--color", "never"]
+
+
 class TestInstallRequirements:
     @patch.object(pywrangler_sync, "_install_requirements_to_vendor")
     @patch.object(pywrangler_sync, "_get_vendor_package_versions")


### PR DESCRIPTION
`pywrangler sync` fails when the environment forces color (e.g. `FORCE_COLOR=1`): uv emits ANSI escapes even when its output is captured, so a freeze line like `\x1b[1mshapely\x1b[0m==2.0.7` passes the `==` filter, lands in the temp requirements file, and uv's requirements parser rejects the escape byte with ``error: Unexpected '<ESC>', expected '-c', '-e', '-r' or the start of a requirement``. This PR passes `--color never` on the `uv pip freeze` invocation whose output is parsed.