### PR TITLE
fix(runtime-sdk): stop losing details of ASGI lifespan failures

### DIFF
--- a/packages/runtime-sdk/src/workers/asgi.py
+++ b/packages/runtime-sdk/src/workers/asgi.py
@@ -127,7 +127,9 @@ async def start_application(app):
                 startup.set_result(True)
             return
         if got["type"] == "lifespan.startup.failed":
-            message = got.get("message", "ASGI lifespan startup failed")
+            # `or`, not a .get default: an empty message field is legal and
+            # would otherwise produce RuntimeError('').
+            message = got.get("message") or "ASGI lifespan startup failed"
             if not startup.done():
                 startup.set_exception(RuntimeError(message))
             return
@@ -136,7 +138,7 @@ async def start_application(app):
                 shutdown_complete.set_result(None)
             return
         if got["type"] == "lifespan.shutdown.failed":
-            message = got.get("message", "ASGI lifespan shutdown failed")
+            message = got.get("message") or "ASGI lifespan shutdown failed"
             if not shutdown_complete.done():
                 shutdown_complete.set_exception(RuntimeError(message))
             return
@@ -161,8 +163,15 @@ async def start_application(app):
                 shutdown_complete.set_result(None)
         except Exception as exc:
             # Spec: an exception raised before startup is acked signals that the
-            # app doesn't support lifespan; swallow it and serve requests anyway.
+            # app doesn't support lifespan; serve requests anyway. Log it, or an
+            # app that crashed mid-startup looks like one with no lifespan
+            # handler at all.
             if not startup.done():
+                logger.debug(
+                    "ASGI lifespan task raised before reporting startup; "
+                    "treating the app as not supporting lifespan",
+                    exc_info=exc,
+                )
                 startup.set_result(False)
                 return
             # After a successful startup, a shutdown-phase error can't affect the

--- a/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
@@ -428,3 +428,49 @@ async def test_multiple_set_cookie_headers_survive():
         "first=1; Path=/",
         "second=2; Path=/",
     ]
+
+
+class _StartupFailEmptyMessageApp:
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.failed", "message": ""})
+            return
+
+
+@pytest.mark.asyncio
+async def test_lifespan_startup_failure_with_empty_message():
+    req = js.Request.new("http://example.com/startup-fail-empty")
+    with pytest.raises(RuntimeError, match="ASGI lifespan startup failed"):
+        await asyncio.wait_for(
+            asgi.fetch(_StartupFailEmptyMessageApp(), req, env), timeout=5
+        )
+
+
+class _PreAckCrashApp:
+    """Raises on the lifespan scope before any ack; HTTP must still serve."""
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            raise RuntimeError("crashed before ack")
+        await receive()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+
+@pytest.mark.asyncio
+async def test_lifespan_preack_crash_is_logged_and_treated_as_unsupported():
+    handler = _install_handler()
+    try:
+        req = js.Request.new("http://example.com/preack-crash")
+        response = await asyncio.wait_for(
+            asgi.fetch(_PreAckCrashApp(), req, env), timeout=5
+        )
+        assert await response.text() == "ok"
+        assert any(
+            "before reporting startup" in record.getMessage()
+            for record in handler.records
+        )
+    finally:
+        _remove_handler(handler)


### PR DESCRIPTION
Two lifespan failure paths discard what went wrong. An empty but present `message` produced `RuntimeError('')`, because a `.get` default only applies when the key is absent. An exception raised before the startup ack was swallowed along with the spec-mandated "this app has no lifespan handler" conclusion, so a crash partway through startup work looked identical to an app that never implemented lifespan; it is now logged at debug level.

### Test Plan

```
$ uv run pytest 'tests/test_in_workerd.py::test_in_workerd[asgi-3.13]' -v
```

(run from `packages/runtime-sdk`)