### PR TITLE
ci: prepare django-cf transfer

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,5 +25,8 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://www.cloudflare.com/cla/'
           branch: 'cla-signatures'
-          allowlist: dependabot[bot],workers-devprod
+          # G4brym authored the django-cf history imported into
+          # packages/django-cf; the two bot accounts authored commits in that
+          # same history and cannot sign a CLA.
+          allowlist: dependabot[bot],workers-devprod,G4brym,google-labs-jules[bot],github-actions[bot]
           lock-pullrequest-aftermerge: false

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,6 +9,11 @@ permissions:
 
 jobs:
   commitlint:
+    # History-import PRs replay upstream commits whose messages predate this
+    # repo's Conventional Commits policy and cannot be rewritten without
+    # destroying the imported history. Label such a PR `skip-commitlint` to
+    # bypass this check; normal PRs are unaffected.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-commitlint') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,11 @@
 default_language_version:
   python: "3.13"
+# packages/django-cf was imported from https://github.com/G4brym/django-cf with
+# its full git history and is intentionally kept byte-for-byte identical to
+# upstream for now. Exclude it from all hooks so the import stays reviewable as
+# a pure history move; drop this once the package is adopted into the monorepo
+# conventions.
+exclude: ^packages/django-cf/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v5.0.0"

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,4 @@
+# Imported from https://github.com/G4brym/django-cf with full git history and
+# kept identical to upstream for now. See the matching exclude in
+# .pre-commit-config.yaml.
+packages/django-cf/


### PR DESCRIPTION
This updates ci setting before we actually transfer django-cf repository into this monorepo. We need to

1) exclude commit authors from CLA signing so that CLA does not complain about the authors that have not signed.
2) exclude linter from checking `django-cf` respository so we can copy-paste the repository as-is without running the linter for now.
3) disable commitlint for specific condition so that we can keep the commit messages as-is.