### PR TITLE
fix(cli): prevent host python path being used when running uv commands

### DIFF
--- a/packages/cli/src/pywrangler/sync.py
+++ b/packages/cli/src/pywrangler/sync.py
@@ -186,7 +186,13 @@ def _install_requirements_to_vendor(
         shutil.rmtree(pyodide_site_packages)
         pyodide_site_packages.mkdir()
 
-    install_cmd = ["uv", "pip", "install"]
+    install_cmd = [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        str(get_pyodide_venv_path()),
+    ]
     if not allow_build:
         install_cmd.append("--no-build")
     else:
@@ -200,7 +206,6 @@ def _install_requirements_to_vendor(
         install_cmd,
         capture_output=True,
         check=False,
-        env=os.environ | {"VIRTUAL_ENV": str(get_pyodide_venv_path())},
     )
 
     if result.returncode != 0:
@@ -243,9 +248,16 @@ def _install_requirements_to_venv(requirements: list[str]) -> str | None:
 
     with temp_requirements_file(requirements) as requirements_file:
         result = run_command(
-            ["uv", "pip", "install", "-r", requirements_file],
+            [
+                "uv",
+                "pip",
+                "install",
+                "--python",
+                str(venv_workers_path),
+                "-r",
+                requirements_file,
+            ],
             check=False,
-            env=os.environ | {"VIRTUAL_ENV": str(venv_workers_path)},
             capture_output=True,
         )
         if result.returncode != 0:
@@ -262,8 +274,14 @@ def _install_requirements_to_venv(requirements: list[str]) -> str | None:
 
 def _log_installed_packages(venv_path: Path) -> None:
     result = run_command(
-        ["uv", "pip", "list", "--format=freeze"],
-        env=os.environ | {"VIRTUAL_ENV": str(venv_path)},
+        [
+            "uv",
+            "pip",
+            "list",
+            "--python",
+            str(venv_path),
+            "--format=freeze",
+        ],
         capture_output=True,
         check=False,
     )
@@ -291,6 +309,8 @@ def _get_vendor_package_versions() -> list[str]:
             "uv",
             "pip",
             "freeze",
+            "--python",
+            str(get_pyodide_venv_path()),
             # This output is parsed, and FORCE_COLOR-style env vars make uv
             # colorize even when captured. "\x1b[1mshapely\x1b[0m==2.0.7"
             # still contains "==", so it survives _parse_pip_freeze and then
@@ -301,7 +321,6 @@ def _get_vendor_package_versions() -> list[str]:
             "--path",
             str(get_vendor_modules_path()),
         ],
-        env=os.environ | {"VIRTUAL_ENV": str(get_pyodide_venv_path())},
         capture_output=True,
     )
     if result.returncode != 0:

--- a/packages/cli/tests/test_in_workerd.py
+++ b/packages/cli/tests/test_in_workerd.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -93,6 +94,7 @@ def test_in_workerd(  # noqa: PLR0913  (too-many-arguments)
         [*pywrangler_cmd, "sync"],
         cwd=target,
         check=True,
+        env=os.environ | {"_PYODIDE_EXTRA_MOUNTS": str(tmp_path)},
     )
 
     # Copy runtime-sdk to the python modules as well

--- a/packages/cli/tests/test_in_workerd.py
+++ b/packages/cli/tests/test_in_workerd.py
@@ -1,6 +1,5 @@
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -71,20 +70,6 @@ def test_in_workerd(  # noqa: PLR0913  (too-many-arguments)
     bundle_cache_dir,
 ):
     compat_date = compat_config.compat_date
-
-    # FIXME:
-    # pywrangler sync fails to install pyodide packages in unittest environment + Python 3.12 + Linux
-    # This is reproducible only in the unittest environment, and doesn't happen
-    # when running the same worker manually.
-    if (
-        (
-            test_dir.name in ("sdk", "entropy-patches")
-            or test_dir.name.startswith("asgi")
-        )
-        and compat_date < "2025-09-29"
-        and sys.platform == "linux"
-    ):
-        pytest.xfail("pywrangler sync + uv + pyodide 3.12 on Linux")
 
     # `wsgi` streams the request body via `pyodide.ffi.run_sync` (JSPI), which
     # is only available in newer Pyodide runtimes.

--- a/packages/cli/tests/test_version_sync.py
+++ b/packages/cli/tests/test_version_sync.py
@@ -44,7 +44,11 @@ def test_get_vendor_package_versions_disables_color():
     with (
         patch.object(pywrangler_sync, "run_command") as mock_run,
         patch.object(pywrangler_sync, "get_vendor_modules_path"),
-        patch.object(pywrangler_sync, "get_pyodide_venv_path"),
+        patch.object(
+            pywrangler_sync,
+            "get_pyodide_venv_path",
+            return_value=Path("pyodide-venv"),
+        ),
     ):
         mock_run.return_value.returncode = 0
         mock_run.return_value.stdout = "shapely==2.0.7\n"
@@ -53,7 +57,15 @@ def test_get_vendor_package_versions_disables_color():
 
     assert result == ["shapely==2.0.7"]
     command = mock_run.call_args[0][0]
-    assert command[:5] == ["uv", "pip", "freeze", "--color", "never"]
+    assert command[:7] == [
+        "uv",
+        "pip",
+        "freeze",
+        "--python",
+        "pyodide-venv",
+        "--color",
+        "never",
+    ]
 
 
 class TestInstallRequirements:


### PR DESCRIPTION
`pywrangler sync` previously selected the Pyodide environment through `VIRTUAL_ENV`. However, the `VIRTUAL_ENV` env variable can be ignored or overridden by uv's internal interpreter discovery logic.  This PR fixes it by explicitly passing `--python` flag to the uv commands, which is [the most dominant flag](https://docs.astral.sh/uv/pip/environments/#using-arbitrary-python-environments).

This fixes a problem that some test were failing in CI in old Python versions + hopefully fixes the CI failure in #177