### PR TITLE
chore(django-cf): apply ruff to the codebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,5 @@
 default_language_version:
   python: "3.13"
-# packages/django-cf was imported from https://github.com/G4brym/django-cf with
-# its full git history and is intentionally kept byte-for-byte identical to
-# upstream for now. Exclude it from all hooks so the import stays reviewable as
-# a pure history move; drop this once the package is adopted into the monorepo
-# conventions.
-exclude: ^packages/django-cf/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v5.0.0"
@@ -46,7 +40,9 @@ repos:
     rev: "v1.14.1"
     hooks:
       - id: mypy
-        exclude: (.*test.*|runtime-sdk)
+        # django-cf has no [tool.mypy] config yet and does not type-check clean
+        # under this hook's defaults; it is annotated in a follow-up.
+        exclude: (.*test.*|runtime-sdk|django-cf)
         additional_dependencies:
           - click
 ci:

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,5 +1,4 @@
-# packages/django-cf now runs the full pre-commit suite (ruff, codespell,
-# shellcheck, ...) but is still skipped by Semgrep. Semgrep's `--config=auto`
-# ruleset is fetched at scan time, so the findings for this package have not
-# been triaged yet; enabling it belongs in its own PR.
+# Imported from https://github.com/G4brym/django-cf with full git history and
+# kept identical to upstream for now. See the matching exclude in
+# .pre-commit-config.yaml.
 packages/django-cf/

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,4 +1,5 @@
-# Imported from https://github.com/G4brym/django-cf with full git history and
-# kept identical to upstream for now. See the matching exclude in
-# .pre-commit-config.yaml.
+# packages/django-cf now runs the full pre-commit suite (ruff, codespell,
+# shellcheck, ...) but is still skipped by Semgrep. Semgrep's `--config=auto`
+# ruleset is fetched at scan time, so the findings for this package have not
+# been triaged yet; enabling it belongs in its own PR.
 packages/django-cf/

--- a/packages/django-cf/README.md
+++ b/packages/django-cf/README.md
@@ -171,7 +171,7 @@ Use Cloudflare R2, a global object storage service, as your Django storage backe
     ```
 
 2.  **Django Settings (`settings.py`):**
-    ```python 
+    ```python
     MEDIA_URL = 'https://pub-xxxxx.r2.dev/'
 
     STORAGES = {
@@ -272,10 +272,10 @@ def serve_media(request, file_path):
     # Add your access control logic here
     if not request.user.is_authenticated:
         return HttpResponseForbidden()
-    
+
     # Check if user has permission to access this file
     # (implement your own permission logic)
-    
+
     try:
         file = default_storage.open(file_path, 'rb')
         return FileResponse(file, content_type='application/octet-stream')
@@ -444,7 +444,7 @@ How long to cache Cloudflare's public keys (in seconds). Cloudflare rotates thes
 5. **Token Validation**: Validates the JWT against Cloudflare's public keys:
    - Validates token signature and expiration
    - Validates audience (AUD) if configured
-6. **User Management**: 
+6. **User Management**:
    - Extracts email and name from JWT claims
    - Creates new Django user if doesn't exist
    - Updates existing user's name if changed

--- a/packages/django-cf/django_cf/__init__.py
+++ b/packages/django-cf/django_cf/__init__.py
@@ -3,8 +3,8 @@ from io import BytesIO
 
 
 async def handle_wsgi(request, app):
-    os.environ.setdefault('DJANGO_ALLOW_ASYNC_UNSAFE', 'false')
-    from js import Object, Response, URL, console
+    os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "false")
+    from js import URL, Object, Response, console
 
     url = URL.new(request.url)
     assert url.protocol[-1] == ":"
@@ -14,36 +14,36 @@ async def handle_wsgi(request, app):
     query_string = url.search[1:]
     method = str(request.method).upper()
 
-    host = url.host.split(':')[0]
+    host = url.host.split(":")[0]
 
     wsgi_request = {
-        'REQUEST_METHOD': method,
-        'PATH_INFO': path,
-        'QUERY_STRING': query_string,
-        'SERVER_NAME': host,
-        'SERVER_PORT': url.port,
-        'SERVER_PROTOCOL': 'HTTP/1.1',
-        'wsgi.input': BytesIO(b''),
-        'wsgi.errors': console.error,
-        'wsgi.version': (1, 0),
-        'wsgi.multithread': False,
-        'wsgi.multiprocess': False,
-        'wsgi.run_once': True,
-        'wsgi.url_scheme': scheme,
+        "REQUEST_METHOD": method,
+        "PATH_INFO": path,
+        "QUERY_STRING": query_string,
+        "SERVER_NAME": host,
+        "SERVER_PORT": url.port,
+        "SERVER_PROTOCOL": "HTTP/1.1",
+        "wsgi.input": BytesIO(b""),
+        "wsgi.errors": console.error,
+        "wsgi.version": (1, 0),
+        "wsgi.multithread": False,
+        "wsgi.multiprocess": False,
+        "wsgi.run_once": True,
+        "wsgi.url_scheme": scheme,
     }
 
-    if request.headers.get('content-type'):
-        wsgi_request['CONTENT_TYPE'] = request.headers.get('content-type')
+    if request.headers.get("content-type"):
+        wsgi_request["CONTENT_TYPE"] = request.headers.get("content-type")
 
-    if request.headers.get('content-length'):
-        wsgi_request['CONTENT_LENGTH'] = request.headers.get('content-length')
+    if request.headers.get("content-length"):
+        wsgi_request["CONTENT_LENGTH"] = request.headers.get("content-length")
 
     for header in request.headers.items():
-        wsgi_request[f'HTTP_{header[0].upper().replace("-", "_")}'] = header[1]
+        wsgi_request[f"HTTP_{header[0].upper().replace('-', '_')}"] = header[1]
 
-    if method in ['POST', 'PUT', 'PATCH']:
+    if method in ["POST", "PUT", "PATCH"]:
         body = (await request._js_request.arrayBuffer()).to_bytes()
-        wsgi_request['wsgi.input'] = BytesIO(body)
+        wsgi_request["wsgi.input"] = BytesIO(body)
 
     def start_response(status_str, response_headers):
         nonlocal status, headers
@@ -54,7 +54,7 @@ async def handle_wsgi(request, app):
         resp = app(wsgi_request, start_response)
     except Exception as exc:
         # library should always print or console log the exception, because a production django should not show end users errors
-        print('Caught exception while loading application:', exc.__str__())
+        print("Caught exception while loading application:", exc.__str__())
         print(exc)
 
         raise exc
@@ -63,12 +63,14 @@ async def handle_wsgi(request, app):
     headers = resp.headers
 
     final_response = Response.new(
-        resp.content.decode('utf-8'), headers=Object.fromEntries(headers.items()), status=status
+        resp.content.decode("utf-8"),
+        headers=Object.fromEntries(headers.items()),
+        status=status,
     )
 
-    for k, v in resp.cookies.items():
+    for v in resp.cookies.values():
         value = str(v)
-        final_response.headers.set('Set-Cookie', value.replace('Set-Cookie: ', '', 1));
+        final_response.headers.set("Set-Cookie", value.replace("Set-Cookie: ", "", 1))
 
     return final_response
 
@@ -90,6 +92,7 @@ class DjangoCFDurableObject:
         self.env = env
 
         from django_cf.db.backends.do.storage import set_storage
+
         set_storage(self.ctx.storage.sql)
 
     def fetch(self, request):

--- a/packages/django-cf/django_cf/db/backends/d1/base.py
+++ b/packages/django-cf/django_cf/db/backends/d1/base.py
@@ -1,6 +1,11 @@
 from django.core.exceptions import ImproperlyConfigured
 
-from ...base_engine import CFDatabaseWrapper, is_read_only_query, CFResult, replace_date_trunc_in_sql
+from ...base_engine import (
+    CFDatabaseWrapper,
+    CFResult,
+    is_read_only_query,
+    replace_date_trunc_in_sql,
+)
 
 
 class DatabaseWrapper(CFDatabaseWrapper):
@@ -29,38 +34,37 @@ class DatabaseWrapper(CFDatabaseWrapper):
 
         try:
             from pyodide.ffi import run_sync
+
             self.run_sync = run_sync
         except ImportError as e:
             print(e)
             raise Exception("Code not running inside a worker!")
-
 
     def process_query(self, query, params=None):
         # Replace django_date_trunc and django_datetime_trunc with SQLite equivalents
         query = replace_date_trunc_in_sql(query)
 
         if params is None:
-            query = query.replace('%s', '?')
+            query = query.replace("%s", "?")
         else:
             new_params = []
             for param in params:
                 if param is None:
-                    query = query.replace('%s', 'null', 1)
+                    query = query.replace("%s", "null", 1)
                 else:
                     new_params.append(param)
-                    query = query.replace('%s', '?', 1)
+                    query = query.replace("%s", "?", 1)
 
             params = new_params
 
-
         if self.cursor()._defer_foreign_keys:
-            return f'''
+            return f"""
             PRAGMA defer_foreign_keys = on
 
             {query}
 
             PRAGMA defer_foreign_keys = off
-            '''
+            """
 
         return query, params
 
@@ -68,12 +72,13 @@ class DatabaseWrapper(CFDatabaseWrapper):
         proc_query, params = self.process_query(query, params)
 
         from workers import env
+
         db = getattr(env, self.binding)
 
         if params:
-            stmt = db.prepare(proc_query).bind(*params);
+            stmt = db.prepare(proc_query).bind(*params)
         else:
-            stmt = db.prepare(proc_query);
+            stmt = db.prepare(proc_query)
 
         read_only = is_read_only_query(proc_query)
         try:
@@ -82,10 +87,17 @@ class DatabaseWrapper(CFDatabaseWrapper):
                 result = CFResult.from_object(query, params, response, len(response), 0)
             else:
                 response = self.run_sync(stmt.all())
-                result = CFResult.from_object(query, params, response.results.to_py(), response.meta.rows_read, response.meta.rows_written,
-                                            response.meta.last_row_id)
+                result = CFResult.from_object(
+                    query,
+                    params,
+                    response.results.to_py(),
+                    response.meta.rows_read,
+                    response.meta.rows_written,
+                    response.meta.last_row_id,
+                )
         except Exception:
             from js import Error
+
             Error.stackTraceLimit = 1e10
             raise Error(Error.new().stack)
 

--- a/packages/django-cf/django_cf/db/backends/do/base.py
+++ b/packages/django-cf/django_cf/db/backends/do/base.py
@@ -1,5 +1,5 @@
-from .storage import get_storage
 from ...base_engine import CFDatabaseWrapper, CFResult
+from .storage import get_storage
 
 
 class DatabaseWrapper(CFDatabaseWrapper):
@@ -10,30 +10,28 @@ class DatabaseWrapper(CFDatabaseWrapper):
     def get_connection_params(self):
         return {}
 
-
     def process_query(self, query, params=None):
         if params is None:
-            query = query.replace('%s', '?')
+            query = query.replace("%s", "?")
         else:
             new_params = []
             for param in params:
                 if param is None:
-                    query = query.replace('%s', 'null', 1)
+                    query = query.replace("%s", "null", 1)
                 else:
                     new_params.append(param)
-                    query = query.replace('%s', '?', 1)
+                    query = query.replace("%s", "?", 1)
 
             params = new_params
 
-
         if self.cursor()._defer_foreign_keys:
-            return f'''
+            return f"""
             PRAGMA defer_foreign_keys = on
 
             {query}
 
             PRAGMA defer_foreign_keys = off
-            '''
+            """
 
         return query, params
 
@@ -43,15 +41,18 @@ class DatabaseWrapper(CFDatabaseWrapper):
         db = get_storage()
 
         if params:
-            stmt = db.exec(proc_query, *params);
+            stmt = db.exec(proc_query, *params)
         else:
-            stmt = db.exec(proc_query);
+            stmt = db.exec(proc_query)
 
         try:
             response = stmt.raw().toArray().to_py()
-            result = CFResult.from_object(query, params, response, stmt.rowsRead, stmt.rowsWritten)
+            result = CFResult.from_object(
+                query, params, response, stmt.rowsRead, stmt.rowsWritten
+            )
         except Exception:
             from js import Error
+
             Error.stackTraceLimit = 1e10
             raise Error(Error.new().stack)
 

--- a/packages/django-cf/django_cf/db/backends/do/storage.py
+++ b/packages/django-cf/django_cf/db/backends/do/storage.py
@@ -1,8 +1,10 @@
 storage = None
 
+
 def set_storage(db):
     global storage
     storage = db
+
 
 def get_storage():
     return storage

--- a/packages/django-cf/django_cf/db/base_engine.py
+++ b/packages/django-cf/django_cf/db/base_engine.py
@@ -1,33 +1,62 @@
 import re
+
 import sqlparse
-from django.db import DatabaseError, Error, DataError, OperationalError, \
-    IntegrityError, InternalError, ProgrammingError, NotSupportedError, InterfaceError
+from django.db import (
+    DatabaseError,
+    DataError,
+    Error,
+    IntegrityError,
+    InterfaceError,
+    InternalError,
+    NotSupportedError,
+    OperationalError,
+    ProgrammingError,
+)
 from django.db.backends.sqlite3.base import DatabaseWrapper as SQLiteDatabaseWrapper
 from django.db.backends.sqlite3.client import DatabaseClient as SQLiteDatabaseClient
-from django.db.backends.sqlite3.creation import DatabaseCreation as SQLiteDatabaseCreation
-from django.db.backends.sqlite3.features import DatabaseFeatures as SQLiteDatabaseFeatures
-from django.db.backends.sqlite3.introspection import DatabaseIntrospection as SQLiteDatabaseIntrospection
-from django.db.backends.sqlite3.operations import DatabaseOperations as SQLiteDatabaseOperations
-from django.db.backends.sqlite3.schema import DatabaseSchemaEditor as SQLiteDatabaseSchemaEditor
-from django.db.models.functions import TruncDate, TruncTime, TruncYear, TruncQuarter, TruncMonth, TruncWeek, TruncDay, TruncHour, TruncMinute, TruncSecond
+from django.db.backends.sqlite3.creation import (
+    DatabaseCreation as SQLiteDatabaseCreation,
+)
+from django.db.backends.sqlite3.features import (
+    DatabaseFeatures as SQLiteDatabaseFeatures,
+)
+from django.db.backends.sqlite3.introspection import (
+    DatabaseIntrospection as SQLiteDatabaseIntrospection,
+)
+from django.db.backends.sqlite3.operations import (
+    DatabaseOperations as SQLiteDatabaseOperations,
+)
+from django.db.backends.sqlite3.schema import (
+    DatabaseSchemaEditor as SQLiteDatabaseSchemaEditor,
+)
+from django.db.models.functions import (
+    TruncDate,
+    TruncDay,
+    TruncHour,
+    TruncMinute,
+    TruncMonth,
+    TruncQuarter,
+    TruncSecond,
+    TruncTime,
+    TruncWeek,
+    TruncYear,
+)
 from django.db.models.sql.compiler import SQLCompiler
 
 
 def replace_date_trunc_in_sql(sql):
     """Replace django_date_trunc and django_datetime_trunc function calls with SQLite equivalents."""
-    if 'django_date_trunc' not in sql and 'django_datetime_trunc' not in sql:
+    if "django_date_trunc" not in sql and "django_datetime_trunc" not in sql:
         return sql
-    
-    import re
-    
+
     # Pattern to match django_datetime_trunc(%s, field, %s, %s) or django_date_trunc(%s, field, %s, %s)
     # The kind is passed as a parameter (%s), so we need to replace the entire function call
     # with a CASE statement that handles all possible kinds
     pattern = r"django_(?:date|datetime)_trunc\(%s,\s*([^,]+),\s*%s,\s*%s\)"
-    
+
     def replace_func(match):
         field = match.group(1).strip()
-        
+
         # Since the kind is a parameter, we need to use a CASE statement
         # that handles all truncation types
         replacement = (
@@ -49,7 +78,7 @@ def replace_date_trunc_in_sql(sql):
             f"END"
         )
         return replacement
-    
+
     return re.sub(pattern, replace_func, sql)
 
 
@@ -91,15 +120,18 @@ class CFDatabaseOperations(SQLiteDatabaseOperations):
         if len(params) > BATCH_SIZE:
             results = ()
             for index in range(0, len(params), BATCH_SIZE):
-                chunk = params[index: index + BATCH_SIZE]
+                chunk = params[index : index + BATCH_SIZE]
                 results += self._quote_params_for_last_executed_query(chunk)
             return results
 
-        sql = "SELECT " + ", ".join(["QUOTE(?)"] * len(params))
+        # Both locals below are unused because the `return` that consumed them is
+        # commented out, so this function falls through and returns None. Left in
+        # place rather than deleted so the intended implementation stays visible.
+        sql = "SELECT " + ", ".join(["QUOTE(?)"] * len(params))  # noqa: F841
         # Bypass Django's wrappers and use the underlying sqlite3 connection
         # to avoid logging this query - it would trigger infinite recursion.
 
-        cursor = self.connection.connection.cursor()
+        cursor = self.connection.connection.cursor()  # noqa: F841
         # Native sqlite3 cursors cannot be used as context managers.
         # try:
         #     return cursor.execute(sql, params).fetchone()
@@ -206,7 +238,9 @@ class CFResult:
         return ret
 
     @staticmethod
-    def from_object(query, params, data, rows_read=None, rows_written=None, last_row_id=None):
+    def from_object(
+        query, params, data, rows_read=None, rows_written=None, last_row_id=None
+    ):
         try:
             from pyodide.ffi import jsnull
         except ImportError:
@@ -223,7 +257,7 @@ class CFResult:
                     else:
                         row_items += (v,)
             else:
-                for k, v in row.items():
+                for v in row.values():
                     if v is jsnull:
                         row_items += (None,)
                     else:
@@ -305,10 +339,10 @@ class CFDatabase:
 
     def execute(self, query, params=None) -> None:
         from decimal import Decimal
-        
+
         # Transform django_date_trunc function calls to SQLite equivalents
         query = replace_date_trunc_in_sql(query)
-        
+
         if params:
             newParams = []
             for v in list(params):
@@ -345,48 +379,71 @@ def is_read_only_query(query: str) -> bool:
         return True
 
     # List of modifying query types
-    modifying_types = {"INSERT", "UPDATE", "DELETE", "CREATE", "ALTER", "DROP", "REPLACE"}
+    modifying_types = {
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "CREATE",
+        "ALTER",
+        "DROP",
+        "REPLACE",
+    }
 
     return statement.get_type().upper() not in modifying_types
 
 
 class CFSQLCompiler(SQLCompiler):
     def as_sql(self, with_limits=True, with_col_aliases=False):
-        sql, params = super().as_sql(with_limits=with_limits, with_col_aliases=with_col_aliases)
+        sql, params = super().as_sql(
+            with_limits=with_limits, with_col_aliases=with_col_aliases
+        )
         # Post-process the SQL to replace django_date_trunc calls with proper SQLite functions
         sql = self._replace_date_trunc_functions(sql)
         return sql, params
 
     def _replace_date_trunc_functions(self, sql):
         """Replace django_date_trunc function calls with SQLite equivalents."""
-        import re
-        
+
         # Pattern to match django_date_trunc('kind', field_name)
         pattern = r"django_date_trunc\('(\w+)',\s*([^)]+)\)"
-        
+
         def replace_func(match):
             kind = match.group(1)
             field = match.group(2)
-            
+
             templates = {
-                'year': f'STRFTIME("%Y-01-01", {field})',
-                'quarter': f'CASE ((CAST(STRFTIME("%m", {field}) AS INTEGER) - 1) / 3 + 1) WHEN 1 THEN STRFTIME("%Y-01-01", {field}) WHEN 2 THEN STRFTIME("%Y-04-01", {field}) WHEN 3 THEN STRFTIME("%Y-07-01", {field}) WHEN 4 THEN STRFTIME("%Y-10-01", {field}) END',
-                'month': f'STRFTIME("%Y-%m-01", {field})',
-                'week': f'DATE({field}, "-" || CAST((CAST(STRFTIME("%w", {field}) AS INTEGER) + 6) % 7 AS TEXT) || " days")',
-                'day': f'DATE({field})',
-                'hour': f'STRFTIME("%Y-%m-%d %H:00:00", {field})',
-                'minute': f'STRFTIME("%Y-%m-%d %H:%M:00", {field})',
-                'second': f'STRFTIME("%Y-%m-%d %H:%M:%S", {field})',
-                'date': f'DATE({field})',
-                'time': f'TIME({field})',
+                "year": f'STRFTIME("%Y-01-01", {field})',
+                "quarter": f'CASE ((CAST(STRFTIME("%m", {field}) AS INTEGER) - 1) / 3 + 1) WHEN 1 THEN STRFTIME("%Y-01-01", {field}) WHEN 2 THEN STRFTIME("%Y-04-01", {field}) WHEN 3 THEN STRFTIME("%Y-07-01", {field}) WHEN 4 THEN STRFTIME("%Y-10-01", {field}) END',
+                "month": f'STRFTIME("%Y-%m-01", {field})',
+                "week": f'DATE({field}, "-" || CAST((CAST(STRFTIME("%w", {field}) AS INTEGER) + 6) % 7 AS TEXT) || " days")',
+                "day": f"DATE({field})",
+                "hour": f'STRFTIME("%Y-%m-%d %H:00:00", {field})',
+                "minute": f'STRFTIME("%Y-%m-%d %H:%M:00", {field})',
+                "second": f'STRFTIME("%Y-%m-%d %H:%M:%S", {field})',
+                "date": f"DATE({field})",
+                "time": f"TIME({field})",
             }
-            
+
             return templates.get(kind, match.group(0))
-        
+
         return re.sub(pattern, replace_func, sql)
 
     def compile(self, node, **extra_context):
-        if isinstance(node, (TruncYear, TruncQuarter, TruncMonth, TruncWeek, TruncDay, TruncHour, TruncMinute, TruncSecond, TruncDate, TruncTime)):
+        if isinstance(
+            node,
+            (
+                TruncYear,
+                TruncQuarter,
+                TruncMonth,
+                TruncWeek,
+                TruncDay,
+                TruncHour,
+                TruncMinute,
+                TruncSecond,
+                TruncDate,
+                TruncTime,
+            ),
+        ):
             return self._compile_date_trunc(node, **extra_context)
         return super().compile(node, **extra_context)
 
@@ -396,16 +453,16 @@ class CFSQLCompiler(SQLCompiler):
         field_sql, params = super().compile(source_expr)
 
         templates = {
-            'year': 'STRFTIME("%Y-01-01", {})'.format(field_sql),
-            'quarter': 'CASE ((CAST(STRFTIME("%%m", {}) AS INTEGER) - 1) / 3 + 1) WHEN 1 THEN STRFTIME("%%Y-01-01", {}) WHEN 2 THEN STRFTIME("%%Y-04-01", {}) WHEN 3 THEN STRFTIME("%%Y-07-01", {}) WHEN 4 THEN STRFTIME("%%Y-10-01", {}) END'.format(field_sql, field_sql, field_sql, field_sql, field_sql),
-            'month': 'STRFTIME("%Y-%m-01", {})'.format(field_sql),
-            'week': 'DATE({}, "-" || CAST((CAST(STRFTIME("%w", {}) AS INTEGER) + 6) %% 7 AS TEXT) || " days")'.format(field_sql, field_sql),
-            'day': 'DATE({})'.format(field_sql),
-            'hour': 'STRFTIME("%Y-%m-%d %H:00:00", {})'.format(field_sql),
-            'minute': 'STRFTIME("%Y-%m-%d %H:%M:00", {})'.format(field_sql),
-            'second': 'STRFTIME("%Y-%m-%d %H:%M:%S", {})'.format(field_sql),
-            'date': 'DATE({})'.format(field_sql),
-            'time': 'TIME({})'.format(field_sql),
+            "year": f'STRFTIME("%Y-01-01", {field_sql})',
+            "quarter": f'CASE ((CAST(STRFTIME("%%m", {field_sql}) AS INTEGER) - 1) / 3 + 1) WHEN 1 THEN STRFTIME("%%Y-01-01", {field_sql}) WHEN 2 THEN STRFTIME("%%Y-04-01", {field_sql}) WHEN 3 THEN STRFTIME("%%Y-07-01", {field_sql}) WHEN 4 THEN STRFTIME("%%Y-10-01", {field_sql}) END',
+            "month": f'STRFTIME("%Y-%m-01", {field_sql})',
+            "week": f'DATE({field_sql}, "-" || CAST((CAST(STRFTIME("%w", {field_sql}) AS INTEGER) + 6) %% 7 AS TEXT) || " days")',
+            "day": f"DATE({field_sql})",
+            "hour": f'STRFTIME("%Y-%m-%d %H:00:00", {field_sql})',
+            "minute": f'STRFTIME("%Y-%m-%d %H:%M:00", {field_sql})',
+            "second": f'STRFTIME("%Y-%m-%d %H:%M:%S", {field_sql})',
+            "date": f"DATE({field_sql})",
+            "time": f"TIME({field_sql})",
         }
 
         sql = templates.get(kind, field_sql)
@@ -433,7 +490,7 @@ class CFDatabaseWrapper(SQLiteDatabaseWrapper):
         if using is None:
             using = default_using
         # The query object is passed in kwargs by Django's ORM
-        query = kwargs.get('query')
+        query = kwargs.get("query")
         return CFSQLCompiler(query, self, using, **kwargs)
 
     def get_database_version(self):
@@ -459,7 +516,7 @@ class CFDatabaseWrapper(SQLiteDatabaseWrapper):
         return
 
     def set_autocommit(
-            self, autocommit, force_begin_transaction_with_broken_autocommit=False
+        self, autocommit, force_begin_transaction_with_broken_autocommit=False
     ):
         return
 

--- a/packages/django-cf/django_cf/middleware/CloudflareAccessMiddleware.py
+++ b/packages/django-cf/django_cf/middleware/CloudflareAccessMiddleware.py
@@ -1,15 +1,15 @@
-import json
 import base64
 import hashlib
-import time
-import urllib.request
-import urllib.error
-from django.contrib.auth import get_user_model, login
-from django.contrib.auth.models import AnonymousUser
-from django.http import JsonResponse
-from django.conf import settings
-from django.core.cache import cache
+import json
 import logging
+import time
+import urllib.error
+import urllib.request
+
+from django.conf import settings
+from django.contrib.auth import get_user_model, login
+from django.core.cache import cache
+from django.http import JsonResponse
 
 logger = logging.getLogger(__name__)
 
@@ -48,11 +48,13 @@ class CloudflareAccessMiddleware:
         self.get_response = get_response
 
         # Validate required settings - at least one must be provided
-        self.aud = getattr(settings, 'CLOUDFLARE_ACCESS_AUD', None)
-        self.team_name = getattr(settings, 'CLOUDFLARE_ACCESS_TEAM_NAME', None)
+        self.aud = getattr(settings, "CLOUDFLARE_ACCESS_AUD", None)
+        self.team_name = getattr(settings, "CLOUDFLARE_ACCESS_TEAM_NAME", None)
 
         if not self.aud and not self.team_name:
-            raise ValueError("Either CLOUDFLARE_ACCESS_AUD or CLOUDFLARE_ACCESS_TEAM_NAME setting is required")
+            raise ValueError(
+                "Either CLOUDFLARE_ACCESS_AUD or CLOUDFLARE_ACCESS_TEAM_NAME setting is required"
+            )
 
         # If team_name is provided, use it to construct the certs URL
         if self.team_name:
@@ -64,8 +66,10 @@ class CloudflareAccessMiddleware:
             self.certs_url = None
 
         # Optional settings
-        self.exempt_paths = getattr(settings, 'CLOUDFLARE_ACCESS_EXEMPT_PATHS', [])
-        self.cache_timeout = getattr(settings, 'CLOUDFLARE_ACCESS_CACHE_TIMEOUT', 3600)  # 1 hour
+        self.exempt_paths = getattr(settings, "CLOUDFLARE_ACCESS_EXEMPT_PATHS", [])
+        self.cache_timeout = getattr(
+            settings, "CLOUDFLARE_ACCESS_CACHE_TIMEOUT", 3600
+        )  # 1 hour
 
     def __call__(self, request):
         # Always try to authenticate with Cloudflare Access if JWT is present
@@ -76,31 +80,28 @@ class CloudflareAccessMiddleware:
                 # Set the user on the request (this overrides any logged-out state)
                 request.user = user
                 # Clear any logout-related session data
-                if hasattr(request, 'session'):
+                if hasattr(request, "session"):
                     # User was logged out but CF Access is still valid, re-authenticate
                     try:
                         login(request, user)
                         logger.info("Logged in user %s", user)
                     except Exception as e:
-                        logger.warning(f"Failed to re-login user after logout: {str(e)}")
-            else:
-                # Check if path is exempt from authentication
-                if not self._is_exempt_path(request.path):
-                    # Authentication failed and path is not exempt, return 401
-                    return JsonResponse(
-                        {'error': 'Cloudflare Access authentication required'},
-                        status=401
-                    )
+                        logger.warning(
+                            f"Failed to re-login user after logout: {str(e)}"
+                        )
+            # Check if path is exempt from authentication
+            elif not self._is_exempt_path(request.path):
+                # Authentication failed and path is not exempt, return 401
+                return JsonResponse(
+                    {"error": "Cloudflare Access authentication required"}, status=401
+                )
                 # Path is exempt, continue with anonymous user
 
         except Exception as e:
             logger.error(f"Cloudflare Access authentication error: {repr(e)}")
             # Only return 500 for non-exempt paths
             if not self._is_exempt_path(request.path):
-                return JsonResponse(
-                    {'error': 'Authentication error'},
-                    status=500
-                )
+                return JsonResponse({"error": "Authentication error"}, status=500)
 
         return self.get_response(request)
 
@@ -158,31 +159,35 @@ class CloudflareAccessMiddleware:
 
             # Validate AUD if configured
             if self.aud:
-                token_aud = decoded_token.get('aud')
+                token_aud = decoded_token.get("aud")
                 if isinstance(token_aud, list):
                     if self.aud not in token_aud:
-                        logger.warning(f"JWT audience mismatch. Expected: {self.aud}, Got: {token_aud}")
+                        logger.warning(
+                            f"JWT audience mismatch. Expected: {self.aud}, Got: {token_aud}"
+                        )
                         return None
                 elif token_aud != self.aud:
-                    logger.warning(f"JWT audience mismatch. Expected: {self.aud}, Got: {token_aud}")
+                    logger.warning(
+                        f"JWT audience mismatch. Expected: {self.aud}, Got: {token_aud}"
+                    )
                     return None
 
             # Validate AUD if not configured but we have a team name
             if not self.aud and self.team_name:
-                token_aud = decoded_token.get('aud')
+                token_aud = decoded_token.get("aud")
                 if not token_aud:
                     logger.warning("No audience found in JWT token")
                     return None
 
             # Extract user information from JWT claims
-            email = decoded_token.get('email')
-            name = decoded_token.get('name', '')
+            email = decoded_token.get("email")
+            name = decoded_token.get("name", "")
 
             # Try to get name from custom claims if not in standard claims
             if not name:
-                custom_claims = decoded_token.get('custom', {})
-                first_name = custom_claims.get('firstName', '')
-                last_name = custom_claims.get('lastName', '')
+                custom_claims = decoded_token.get("custom", {})
+                first_name = custom_claims.get("firstName", "")
+                last_name = custom_claims.get("lastName", "")
                 if first_name or last_name:
                     name = f"{first_name} {last_name}".strip()
 
@@ -201,17 +206,17 @@ class CloudflareAccessMiddleware:
     def _extract_jwt_token(self, request):
         """Extract JWT token from CF-Access-Jwt-Assertion header or cf_authorization cookie."""
         # Try header first (most common)
-        jwt_token = request.META.get('HTTP_CF_ACCESS_JWT_ASSERTION')
+        jwt_token = request.META.get("HTTP_CF_ACCESS_JWT_ASSERTION")
         if jwt_token:
             return jwt_token
 
         # Try cookie
-        jwt_token = request.COOKIES.get('CF_Authorization')
+        jwt_token = request.COOKIES.get("CF_Authorization")
         if jwt_token:
             return jwt_token
 
         # Try alternative cookie name
-        jwt_token = request.COOKIES.get('cf_authorization')
+        jwt_token = request.COOKIES.get("cf_authorization")
         if jwt_token:
             return jwt_token
 
@@ -221,24 +226,28 @@ class CloudflareAccessMiddleware:
         """Extract team name from JWT token without validation (for bootstrapping)."""
         try:
             # Split JWT into parts
-            parts = jwt_token.split('.')
+            parts = jwt_token.split(".")
             if len(parts) != 3:
                 return None
 
             # Decode payload (add padding if needed)
             payload_part = parts[1]
-            payload_part += '=' * (4 - len(payload_part) % 4)
+            payload_part += "=" * (4 - len(payload_part) % 4)
             payload_bytes = base64.urlsafe_b64decode(payload_part)
-            payload = json.loads(payload_bytes.decode('utf-8'))
+            payload = json.loads(payload_bytes.decode("utf-8"))
 
             # Extract issuer (iss) claim - format: https://teamname.cloudflareaccess.com
-            issuer = payload.get('iss')
+            issuer = payload.get("iss")
             if not issuer:
                 return None
 
             # Extract team name from issuer URL
-            if issuer.startswith('https://') and issuer.endswith('.cloudflareaccess.com'):
-                team_name = issuer.replace('https://', '').replace('.cloudflareaccess.com', '')
+            if issuer.startswith("https://") and issuer.endswith(
+                ".cloudflareaccess.com"
+            ):
+                team_name = issuer.replace("https://", "").replace(
+                    ".cloudflareaccess.com", ""
+                )
                 return team_name
 
             return None
@@ -249,7 +258,9 @@ class CloudflareAccessMiddleware:
     def _get_cloudflare_public_keys(self):
         """Retrieve Cloudflare public keys, with caching."""
         # Use team_name for cache key, or extract from team_domain if available
-        cache_key_team = self.team_name or (self.team_domain.split('.')[0] if self.team_domain else 'unknown')
+        cache_key_team = self.team_name or (
+            self.team_domain.split(".")[0] if self.team_domain else "unknown"
+        )
         cache_key = f"cloudflare_access_keys_{cache_key_team}"
         cached_keys = cache.get(cache_key)
 
@@ -267,9 +278,11 @@ class CloudflareAccessMiddleware:
             try:
                 with urllib.request.urlopen(self.certs_url) as response:
                     if response.status == 200:
-                        data = json.loads(response.read().decode('utf-8'))
+                        data = json.loads(response.read().decode("utf-8"))
                     else:
-                        logger.error(f"Failed to fetch Cloudflare keys: HTTP {response.status}")
+                        logger.error(
+                            f"Failed to fetch Cloudflare keys: HTTP {response.status}"
+                        )
                         return None
             except urllib.error.URLError as e:
                 logger.error(f"Network error fetching Cloudflare keys: {str(e)}")
@@ -278,19 +291,21 @@ class CloudflareAccessMiddleware:
                 logger.error(f"Unexpected error fetching Cloudflare keys: {str(e)}")
                 return None
 
-        keys = data.get('keys', [])
+        keys = data.get("keys", [])
 
         # Process keys for JWT validation
         processed_keys = []
         for key_info in keys:
-            if key_info.get('kty') == 'RSA':
+            if key_info.get("kty") == "RSA":
                 # Extract RSA components
                 try:
                     processed_key = self._process_rsa_key(key_info)
                     if processed_key:
                         processed_keys.append(processed_key)
                 except Exception as e:
-                    logger.warning(f"Failed to process key {key_info.get('kid')}: {str(e)}")
+                    logger.warning(
+                        f"Failed to process key {key_info.get('kid')}: {str(e)}"
+                    )
                     continue
 
         # Cache the keys
@@ -301,9 +316,9 @@ class CloudflareAccessMiddleware:
         """Process RSA key from JWK format to usable format."""
         try:
             # Extract RSA components from JWK
-            n = key_info.get('n')  # modulus
-            e = key_info.get('e')  # exponent
-            kid = key_info.get('kid')
+            n = key_info.get("n")  # modulus
+            e = key_info.get("e")  # exponent
+            kid = key_info.get("kid")
 
             if not n or not e:
                 return None
@@ -313,9 +328,9 @@ class CloudflareAccessMiddleware:
             e_bytes = self._base64url_decode(e)
 
             return {
-                'kid': kid,
-                'n': int.from_bytes(n_bytes, 'big'),
-                'e': int.from_bytes(e_bytes, 'big')
+                "kid": kid,
+                "n": int.from_bytes(n_bytes, "big"),
+                "e": int.from_bytes(e_bytes, "big"),
             }
         except Exception as e:
             logger.warning(f"Failed to process RSA key: {str(e)}")
@@ -324,14 +339,14 @@ class CloudflareAccessMiddleware:
     def _base64url_decode(self, data):
         """Decode base64url encoded data."""
         # Add padding if needed
-        data += '=' * (4 - len(data) % 4)
+        data += "=" * (4 - len(data) % 4)
         return base64.urlsafe_b64decode(data)
 
     def _decode_and_verify_jwt(self, jwt_token, key_data):
         """Decode and verify JWT token using RSA key."""
         try:
             # Split JWT into parts
-            parts = jwt_token.split('.')
+            parts = jwt_token.split(".")
             if len(parts) != 3:
                 raise ValueError("Invalid JWT format")
 
@@ -339,32 +354,32 @@ class CloudflareAccessMiddleware:
 
             # Decode header
             header_bytes = self._base64url_decode(header_part)
-            header = json.loads(header_bytes.decode('utf-8'))
+            header = json.loads(header_bytes.decode("utf-8"))
 
             # Check if this key matches the kid in the header
-            if header.get('kid') != key_data.get('kid'):
+            if header.get("kid") != key_data.get("kid"):
                 raise ValueError("Key ID mismatch")
 
             # Check algorithm
-            if header.get('alg') != 'RS256':
+            if header.get("alg") != "RS256":
                 raise ValueError("Unsupported algorithm")
 
             # Decode payload
             payload_bytes = self._base64url_decode(payload_part)
-            payload = json.loads(payload_bytes.decode('utf-8'))
+            payload = json.loads(payload_bytes.decode("utf-8"))
 
             # Check expiration
-            exp = payload.get('exp')
+            exp = payload.get("exp")
             if exp and exp < time.time():
                 raise ValueError("Token expired")
 
             # Check not before
-            nbf = payload.get('nbf')
+            nbf = payload.get("nbf")
             if nbf and nbf > time.time():
                 raise ValueError("Token not yet valid")
 
             # Verify signature
-            message = f"{header_part}.{payload_part}".encode('utf-8')
+            message = f"{header_part}.{payload_part}".encode()
             signature = self._base64url_decode(signature_part)
 
             if not self._verify_rsa_signature(message, signature, key_data):
@@ -386,15 +401,15 @@ class CloudflareAccessMiddleware:
 
             # Create PKCS#1 v1.5 padding for SHA-256
             # DigestInfo for SHA-256: 30 31 30 0d 06 09 60 86 48 01 65 03 04 02 01 05 00 04 20
-            digest_info = bytes.fromhex('3031300d060960864801650304020105000420')
+            digest_info = bytes.fromhex("3031300d060960864801650304020105000420")
             padded_hash = digest_info + message_hash
 
             # RSA signature verification
-            n = key_data['n']
-            e = key_data['e']
+            n = key_data["n"]
+            e = key_data["e"]
 
             # Convert signature to integer
-            sig_int = int.from_bytes(signature, 'big')
+            sig_int = int.from_bytes(signature, "big")
 
             # RSA verification: sig^e mod n
             decrypted_int = pow(sig_int, e, n)
@@ -404,20 +419,26 @@ class CloudflareAccessMiddleware:
             key_length = (n.bit_length() + 7) // 8
 
             # Ensure we have the right number of bytes
-            decrypted_bytes = decrypted_int.to_bytes(key_length, 'big')
+            decrypted_bytes = decrypted_int.to_bytes(key_length, "big")
 
             # Check minimum length
             if len(decrypted_bytes) < len(padded_hash) + 11:
-                logger.debug(f"Decrypted bytes too short: {len(decrypted_bytes)} < {len(padded_hash) + 11}")
+                logger.debug(
+                    f"Decrypted bytes too short: {len(decrypted_bytes)} < {len(padded_hash) + 11}"
+                )
                 return False
 
             # PKCS#1 v1.5 padding format: 0x00 0x01 [0xFF padding] 0x00 [DigestInfo + Hash]
             if len(decrypted_bytes) == 0 or decrypted_bytes[0] != 0x00:
-                logger.debug(f"Invalid padding: first byte is {decrypted_bytes[0]:02x}, expected 0x00")
+                logger.debug(
+                    f"Invalid padding: first byte is {decrypted_bytes[0]:02x}, expected 0x00"
+                )
                 return False
 
             if len(decrypted_bytes) < 2 or decrypted_bytes[1] != 0x01:
-                logger.debug(f"Invalid padding: second byte is {decrypted_bytes[1]:02x}, expected 0x01")
+                logger.debug(
+                    f"Invalid padding: second byte is {decrypted_bytes[1]:02x}, expected 0x01"
+                )
                 return False
 
             # Find the 0x00 separator
@@ -427,7 +448,9 @@ class CloudflareAccessMiddleware:
                     separator_idx = i
                     break
                 elif decrypted_bytes[i] != 0xFF:
-                    logger.debug(f"Invalid padding byte at position {i}: {decrypted_bytes[i]:02x}, expected 0xFF")
+                    logger.debug(
+                        f"Invalid padding byte at position {i}: {decrypted_bytes[i]:02x}, expected 0xFF"
+                    )
                     return False
 
             if separator_idx == -1:
@@ -440,10 +463,12 @@ class CloudflareAccessMiddleware:
                 return False
 
             # Extract and compare the hash
-            extracted_hash = decrypted_bytes[separator_idx + 1:]
+            extracted_hash = decrypted_bytes[separator_idx + 1 :]
 
             if len(extracted_hash) != len(padded_hash):
-                logger.debug(f"Hash length mismatch: {len(extracted_hash)} != {len(padded_hash)}")
+                logger.debug(
+                    f"Hash length mismatch: {len(extracted_hash)} != {len(padded_hash)}"
+                )
                 return False
 
             result = extracted_hash == padded_hash
@@ -467,23 +492,23 @@ class CloudflareAccessMiddleware:
             # Update name if it has changed
             if name and user.get_full_name() != name:
                 # Split name into first and last name
-                name_parts = name.split(' ', 1)
+                name_parts = name.split(" ", 1)
                 user.first_name = name_parts[0]
-                user.last_name = name_parts[1] if len(name_parts) > 1 else ''
+                user.last_name = name_parts[1] if len(name_parts) > 1 else ""
                 user.save()
 
             return user
 
         except User.DoesNotExist:
             # Create new user
-            name_parts = name.split(' ', 1) if name else ['', '']
+            name_parts = name.split(" ", 1) if name else ["", ""]
 
             user = User.objects.create_user(
                 username=email,  # Use email as username
                 email=email,
                 first_name=name_parts[0],
-                last_name=name_parts[1] if len(name_parts) > 1 else '',
-                is_active=True
+                last_name=name_parts[1] if len(name_parts) > 1 else "",
+                is_active=True,
             )
 
             logger.info(f"Created new user from Cloudflare Access: {email}")

--- a/packages/django-cf/django_cf/middleware/__init__.py
+++ b/packages/django-cf/django_cf/middleware/__init__.py
@@ -1,1 +1,3 @@
 from .CloudflareAccessMiddleware import CloudflareAccessMiddleware
+
+__all__ = ["CloudflareAccessMiddleware"]

--- a/packages/django-cf/django_cf/storage/__init__.py
+++ b/packages/django-cf/django_cf/storage/__init__.py
@@ -1,3 +1,3 @@
 from .r2 import R2Storage
 
-__all__ = ['R2Storage']
+__all__ = ["R2Storage"]

--- a/packages/django-cf/django_cf/storage/r2.py
+++ b/packages/django-cf/django_cf/storage/r2.py
@@ -1,16 +1,19 @@
 import os
 from datetime import datetime
 from io import BytesIO
-from django.core.files.storage import Storage
+
 from django.core.files.base import File
+from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
 from js import Uint8Array
+
 
 class R2File(File):
     """
     A file-like object for R2 storage.
     """
-    def __init__(self, name, storage, mode='rb'):
+
+    def __init__(self, name, storage, mode="rb"):
         self.name = name
         self._storage = storage
         self._mode = mode
@@ -27,7 +30,7 @@ class R2File(File):
         return self.file.read(num_bytes)
 
     def write(self, content):
-        if 'w' not in self._mode and 'a' not in self._mode:
+        if "w" not in self._mode and "a" not in self._mode:
             raise AttributeError("File not opened for writing")
         return self.file.write(content)
 
@@ -63,9 +66,9 @@ class R2Storage(Storage):
         }
     """
 
-    def __init__(self, binding='BUCKET', location='', allow_overwrite=False):
+    def __init__(self, binding="BUCKET", location="", allow_overwrite=False):
         self.binding = binding
-        self.location = location.strip('/')
+        self.location = location.strip("/")
         self.allow_overwrite = allow_overwrite
         self._bucket = None
         self._run_sync = None
@@ -76,12 +79,14 @@ class R2Storage(Storage):
             if self._run_sync is None:
                 try:
                     from pyodide.ffi import run_sync
+
                     self._run_sync = run_sync
 
-                except ImportError as e:
+                except ImportError:
                     raise Exception("Code not running inside a worker!")
 
             from workers import env
+
             self._bucket = getattr(env, self.binding)
 
         return self._bucket
@@ -92,7 +97,7 @@ class R2Storage(Storage):
             return f"{self.location}/{name}"
         return name
 
-    def _open(self, name, mode='rb'):
+    def _open(self, name, mode="rb"):
         """
         Retrieve the file from R2.
         """
@@ -120,7 +125,7 @@ class R2Storage(Storage):
         """
         full_path = self._full_path(name)
 
-        if hasattr(content, 'read'):
+        if hasattr(content, "read"):
             file_content = content.read()
             file_content = Uint8Array.new(file_content)
         else:
@@ -129,10 +134,12 @@ class R2Storage(Storage):
         bucket = self._get_bucket()
 
         options = {}
-        if hasattr(content, 'content_type') and content.content_type:
-            options['httpMetadata'] = {'contentType': content.content_type}
+        if hasattr(content, "content_type") and content.content_type:
+            options["httpMetadata"] = {"contentType": content.content_type}
 
-        self._run_sync(bucket.put(full_path, file_content, options if options else None))
+        self._run_sync(
+            bucket.put(full_path, file_content, options if options else None)
+        )
         return name
 
     def delete(self, name):
@@ -163,25 +170,28 @@ class R2Storage(Storage):
             tuple: (directories, files)
         """
         full_path = self._full_path(path)
-        if full_path and not full_path.endswith('/'):
-            full_path += '/'
+        if full_path and not full_path.endswith("/"):
+            full_path += "/"
 
         bucket = self._get_bucket()
-        result = self._run_sync(bucket.list({'prefix': full_path, 'delimiter': '/'})).to_py()
+        result = self._run_sync(
+            bucket.list({"prefix": full_path, "delimiter": "/"})
+        ).to_py()
 
         directories = []
         files = []
 
-        delimited_prefixes = result.get('delimitedPrefixes', [])
+        delimited_prefixes = result.get("delimitedPrefixes", [])
         for delimited_prefix in delimited_prefixes:
-            directories.append(os.path.basename(delimited_prefix.replace(full_path, "", 1).rstrip('/')))
+            directories.append(
+                os.path.basename(delimited_prefix.replace(full_path, "", 1).rstrip("/"))
+            )
 
-
-        objects = result.get('objects', [])
+        objects = result.get("objects", [])
         for obj in objects:
             _obj = obj.to_py()
 
-            if not obj.key.endswith('/'):
+            if not obj.key.endswith("/"):
                 files.append(os.path.basename(obj.key))
 
         return directories, files
@@ -194,7 +204,7 @@ class R2Storage(Storage):
         try:
             bucket = self._get_bucket()
             metadata = self._run_sync(bucket.head(full_path)).to_py()
-            if metadata and hasattr(metadata, 'size'):
+            if metadata and hasattr(metadata, "size"):
                 return metadata.size
             return 0
         except Exception:
@@ -203,20 +213,20 @@ class R2Storage(Storage):
     def url(self, name):
         """
         Return the URL for accessing the file.
-        
+
         Uses Django's MEDIA_URL setting to construct the file URL.
         Ensure your web server is configured to serve files from R2 at the MEDIA_URL path.
         """
         from django.conf import settings
-        
-        if not hasattr(settings, 'MEDIA_URL') or not settings.MEDIA_URL:
+
+        if not hasattr(settings, "MEDIA_URL") or not settings.MEDIA_URL:
             raise ValueError(
                 "MEDIA_URL must be configured in Django settings to use R2Storage. "
                 "Configure your web server to proxy requests from MEDIA_URL to your R2 bucket."
             )
-        
+
         full_path = self._full_path(name)
-        media_url = settings.MEDIA_URL.rstrip('/')
+        media_url = settings.MEDIA_URL.rstrip("/")
         return f"{media_url}/{full_path}"
 
     def get_accessed_time(self, name):
@@ -242,7 +252,7 @@ class R2Storage(Storage):
             bucket = self._get_bucket()
             metadata = self._run_sync(bucket.head(full_path)).to_py()
 
-            if metadata and hasattr(metadata, 'uploaded'):
+            if metadata and hasattr(metadata, "uploaded"):
                 uploaded = metadata.uploaded
                 if isinstance(uploaded, datetime):
                     return uploaded

--- a/packages/django-cf/pyproject.toml
+++ b/packages/django-cf/pyproject.toml
@@ -45,6 +45,60 @@ where = ["."]
 include = ["django_cf", "django_cf.*"]
 exclude = ["tests*", "docs*", "templates*", ".github*", "*.__pycache__"]
 
+[tool.ruff]
+# django-cf still declares `requires-python = ">=3.12"`, so the target version is
+# py312 here while packages/cli and packages/runtime-sdk use py311.
+target-version = "py312"
+# Generated/copied trees that only exist after `npm run setup-test`.
+extend-exclude = [".wrangler", "python_modules", "staticfiles"]
+lint.select = [
+  "B0",     # bugbear (all B0* checks enabled by default)
+  "B904",   # bugbear (Within an except clause, raise exceptions with raise ... from err)
+  "B905",   # bugbear (zip() without an explicit strict= parameter set.)
+  "C4",     # flake8-comprehensions
+  "C9",     # mccabe complexity
+  "E",      # pycodestyles
+  "F",      # pyflakes
+  "I",      # isort
+  "PERF",   # Perflint
+  "PGH",    # pygrep-hooks
+  "PL",     # Pylint
+  "UP",     # pyupgrade
+  "W",      # pycodestyles
+]
+lint.ignore = [
+  # Shared across every package in this monorepo.
+  "E402",
+  "E501",
+  "E731",
+  "E741",
+  "PLW2901",
+  "UP031",
+  # Deferred: satisfying these requires behavioural or structural changes to
+  # code imported from https://github.com/G4brym/django-cf, so they are turned
+  # off to keep the lint adoption commit mechanical. Re-enable one rule per PR.
+  "B904",    # `raise ... from err` alters exception chaining and tracebacks
+  "B905",    # `zip(strict=True)` can raise where the loose zip silently truncates
+  "C901",    # too complex; needs function decomposition (also ignored by runtime-sdk)
+  "PERF401", # manual-list-comprehension; needs a loop rewrite
+  "PLR0911", # too many return statements (also ignored by runtime-sdk)
+  "PLR0912", # too many branches; needs decomposition
+  "PLR0913", # too many arguments; signature change
+  "PLR0915", # too many statements (also ignored by runtime-sdk)
+  "PLR2004", # magic value comparison; needs named constants
+  "PLW0603", # global statement; architectural, see db/backends/do/storage.py
+  "UP038",   # `isinstance(x, X | Y)` (also ignored by runtime-sdk)
+]
+lint.flake8-comprehensions.allow-dict-calls-with-keyword-arguments = true
+# Pytest fixtures are imported for their side effect and then shadowed by the
+# test function parameter of the same name, which reads as F811 to ruff.
+lint.per-file-ignores."tests/**" = ["F811"]
+# tests/utils.py launches `wrangler dev` in its own process group.
+lint.per-file-ignores."tests/utils.py" = ["PLW1509"]
+# Generated Django scaffolding kept verbatim so it stays copy-pasteable.
+lint.per-file-ignores."tests/servers/**" = ["F401"]
+lint.per-file-ignores."templates/**" = ["F401"]
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra -q"

--- a/packages/django-cf/pyproject.toml
+++ b/packages/django-cf/pyproject.toml
@@ -46,10 +46,7 @@ include = ["django_cf", "django_cf.*"]
 exclude = ["tests*", "docs*", "templates*", ".github*", "*.__pycache__"]
 
 [tool.ruff]
-# django-cf still declares `requires-python = ">=3.12"`, so the target version is
-# py312 here while packages/cli and packages/runtime-sdk use py311.
 target-version = "py312"
-# Generated/copied trees that only exist after `npm run setup-test`.
 extend-exclude = [".wrangler", "python_modules", "staticfiles"]
 lint.select = [
   "B0",     # bugbear (all B0* checks enabled by default)

--- a/packages/django-cf/templates/d1/README.md
+++ b/packages/django-cf/templates/d1/README.md
@@ -37,15 +37,15 @@ template-root/
 
 1.  **Install Dependencies:**
     Ensure you have Node.js, npm, and Python installed. Then:
-    
+
     ```bash
     # Install Node.js dependencies
     npm install
-    
+
     # Install Python dependencies
     uv sync
     ```
-    
+
     If you don't have `uv` installed, install it first:
     ```bash
     pip install uv

--- a/packages/django-cf/templates/d1/src/app/asgi.py
+++ b/packages/django-cf/templates/d1/src/app/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
 
 application = get_asgi_application()

--- a/packages/django-cf/templates/d1/src/app/settings.py
+++ b/packages/django-cf/templates/d1/src/app/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/5.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
+
 import os
 from pathlib import Path
 
@@ -20,72 +21,69 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-n+hxsvm6_5^5kx2xxe0@oq6@9laf0%&%)@du(pn6-(3enfoha_'
+SECRET_KEY = "django-insecure-n+hxsvm6_5^5kx2xxe0@oq6@9laf0%&%)@du(pn6-(3enfoha_"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
 
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-
-    'blog',
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "blog",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-ROOT_URLCONF = 'app.urls'
+ROOT_URLCONF = "app.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            BASE_DIR.joinpath('templates')
-        ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR.joinpath("templates")],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'app.wsgi.application'
+WSGI_APPLICATION = "app.wsgi.application"
 
 
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
 # Workers CI is missing the sqlite3 module, to build the staticfiles, we must disable the engine
-if os.getenv('WORKERS_CI') == "1":
+if os.getenv("WORKERS_CI") == "1":
     DATABASES = {}
 else:
     DATABASES = {
-        'default': {
-            'ENGINE': 'django_cf.db.backends.d1',
+        "default": {
+            "ENGINE": "django_cf.db.backends.d1",
             # 'CLOUDFLARE_BINDING' should match the binding name in your wrangler.toml
-            'CLOUDFLARE_BINDING': 'DB',
+            "CLOUDFLARE_BINDING": "DB",
         }
     }
 
@@ -94,16 +92,16 @@ else:
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
 
@@ -111,9 +109,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.1/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 USE_I18N = False
 
@@ -123,10 +121,10 @@ USE_TZ = False
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
-STATIC_URL = 'static/'
-STATIC_ROOT = BASE_DIR.parent.joinpath('staticfiles').joinpath('static')
+STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR.parent.joinpath("staticfiles").joinpath("static")
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/packages/django-cf/templates/d1/src/app/urls.py
+++ b/packages/django-cf/templates/d1/src/app/urls.py
@@ -14,29 +14,37 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.contrib.auth import get_user_model
+from django.contrib.auth.decorators import user_passes_test
 from django.core.management import call_command
 from django.http import JsonResponse
-from django.urls import path, include
-from django.contrib.auth.decorators import user_passes_test
+from django.urls import include, path
+
 
 def is_superuser(user):
     return user.is_authenticated and user.is_superuser
 
+
 # @user_passes_test(is_superuser)
 def create_admin_view(request):
     User = get_user_model()
-    username = 'admin' # Or get from request, config, etc.
-    email = 'admin@example.com' # Or get from request, config, etc.
+    username = "admin"  # Or get from request, config, etc.
+    email = "admin@example.com"  # Or get from request, config, etc.
     # IMPORTANT: Change this password or manage it securely!
-    password = 'password'
+    password = "password"
 
     if not User.objects.filter(username=username).exists():
         User.objects.create_superuser(username, email, password)
-        return JsonResponse({"status": "success", "message": f"Admin user '{username}' created."})
+        return JsonResponse(
+            {"status": "success", "message": f"Admin user '{username}' created."}
+        )
     else:
-        return JsonResponse({"status": "info", "message": f"Admin user '{username}' already exists."})
+        return JsonResponse(
+            {"status": "info", "message": f"Admin user '{username}' already exists."}
+        )
+
 
 # @user_passes_test(is_superuser)
 def run_migrations_view(request):
@@ -48,10 +56,9 @@ def run_migrations_view(request):
 
 
 urlpatterns = [
-    path('', include('blog.urls')),
-
-    path('admin/', admin.site.urls),
+    path("", include("blog.urls")),
+    path("admin/", admin.site.urls),
     # Management endpoints - secure these appropriately for your application
-    path('__create_admin__/', create_admin_view, name='create_admin'),
-    path('__run_migrations__/', run_migrations_view, name='run_migrations'),
+    path("__create_admin__/", create_admin_view, name="create_admin"),
+    path("__run_migrations__/", run_migrations_view, name="run_migrations"),
 ]

--- a/packages/django-cf/templates/d1/src/app/wsgi.py
+++ b/packages/django-cf/templates/d1/src/app/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
 
 application = get_wsgi_application()

--- a/packages/django-cf/templates/d1/src/blog/admin.py
+++ b/packages/django-cf/templates/d1/src/blog/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from .models import Post
 
 admin.site.register(Post)

--- a/packages/django-cf/templates/d1/src/blog/apps.py
+++ b/packages/django-cf/templates/d1/src/blog/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class BlogConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'blog'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "blog"

--- a/packages/django-cf/templates/d1/src/blog/migrations/0001_initial.py
+++ b/packages/django-cf/templates/d1/src/blog/migrations/0001_initial.py
@@ -5,30 +5,36 @@ from django.db import migrations, models
 
 
 def insert_dummy_blog_post(apps, schema_editor):
-    Post = apps.get_model('blog', 'Post')
+    Post = apps.get_model("blog", "Post")
 
     # Insert the record
     Post.objects.create(
-        title='Example Post',
-        content="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+        title="Example Post",
+        content="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
     )
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
-            name='Post',
+            name="Post",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('title', models.CharField(max_length=200)),
-                ('content', models.TextField()),
-                ('pub_date', models.DateTimeField(default=django.utils.timezone.now)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("title", models.CharField(max_length=200)),
+                ("content", models.TextField()),
+                ("pub_date", models.DateTimeField(default=django.utils.timezone.now)),
             ],
         ),
         migrations.RunPython(

--- a/packages/django-cf/templates/d1/src/blog/models.py
+++ b/packages/django-cf/templates/d1/src/blog/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 
+
 class Post(models.Model):
     title = models.CharField(max_length=200)
     content = models.TextField()

--- a/packages/django-cf/templates/d1/src/blog/urls.py
+++ b/packages/django-cf/templates/d1/src/blog/urls.py
@@ -3,9 +3,9 @@ from django.views.generic import TemplateView
 
 from . import views
 
-app_name = 'blog'
+app_name = "blog"
 urlpatterns = [
-    path('', TemplateView.as_view(template_name='landing.html'), name='landing'),
-    path('blog/', views.post_list, name='post_list'),
-    path('blog/post/<int:pk>/', views.post_detail, name='post_detail'),
+    path("", TemplateView.as_view(template_name="landing.html"), name="landing"),
+    path("blog/", views.post_list, name="post_list"),
+    path("blog/post/<int:pk>/", views.post_detail, name="post_detail"),
 ]

--- a/packages/django-cf/templates/d1/src/blog/views.py
+++ b/packages/django-cf/templates/d1/src/blog/views.py
@@ -1,10 +1,13 @@
-from django.shortcuts import render, get_object_or_404
+from django.shortcuts import get_object_or_404, render
+
 from .models import Post
 
+
 def post_list(request):
-    posts = Post.objects.order_by('-pub_date')
-    return render(request, 'blog/post_list.html', {'posts': posts})
+    posts = Post.objects.order_by("-pub_date")
+    return render(request, "blog/post_list.html", {"posts": posts})
+
 
 def post_detail(request, pk):
     post = get_object_or_404(Post, pk=pk)
-    return render(request, 'blog/post_detail.html', {'post': post})
+    return render(request, "blog/post_detail.html", {"post": post})

--- a/packages/django-cf/templates/d1/src/index.py
+++ b/packages/django-cf/templates/d1/src/index.py
@@ -1,6 +1,8 @@
-from workers import WorkerEntrypoint
-from django_cf import DjangoCF
 from app.wsgi import application
+from workers import WorkerEntrypoint
+
+from django_cf import DjangoCF
+
 
 class Default(DjangoCF, WorkerEntrypoint):
     def get_app(self):

--- a/packages/django-cf/templates/d1/src/manage.py
+++ b/packages/django-cf/templates/d1/src/manage.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -18,5 +19,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/packages/django-cf/templates/d1/src/templates/blog/base.html
+++ b/packages/django-cf/templates/d1/src/templates/blog/base.html
@@ -13,7 +13,7 @@
             -webkit-text-fill-color: transparent;
             background-clip: text;
         }
-        
+
         .glass-effect {
             background: rgba(255, 255, 255, 0.08);
             backdrop-filter: blur(10px);

--- a/packages/django-cf/templates/d1/src/templates/landing.html
+++ b/packages/django-cf/templates/d1/src/templates/landing.html
@@ -16,32 +16,32 @@
                 transform: translateY(0);
             }
         }
-        
+
         @keyframes spin {
             to { transform: rotate(360deg); }
         }
-        
+
         .animate-fade-in-up {
             animation: fadeInUp 0.6s ease forwards;
         }
-        
+
         .animate-spin-custom {
             animation: spin 1s linear infinite;
         }
-        
+
         .gradient-text {
             background: linear-gradient(135deg, #10b981 0%, #059669 100%);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
         }
-        
+
         .glass-effect {
             background: rgba(255, 255, 255, 0.08);
             backdrop-filter: blur(10px);
             border: 1px solid rgba(255, 255, 255, 0.1);
         }
-        
+
         .status-message {
             position: fixed;
             top: 20px;
@@ -50,7 +50,7 @@
             z-index: 50;
             animation: slideDown 0.3s ease;
         }
-        
+
         @keyframes slideDown {
             from {
                 opacity: 0;
@@ -220,14 +220,14 @@
             const container = document.getElementById('statusContainer');
             const bgColor = type === 'success' ? 'bg-emerald-500/20 border-emerald-500/50' : 'bg-red-500/20 border-red-500/50';
             const textColor = type === 'success' ? 'text-emerald-300' : 'text-red-300';
-            
+
             const statusEl = document.createElement('div');
             statusEl.className = `status-message glass-effect rounded-lg px-6 py-3 ${bgColor} ${textColor} font-semibold`;
             statusEl.textContent = message;
-            
+
             container.innerHTML = '';
             container.appendChild(statusEl);
-            
+
             setTimeout(() => {
                 statusEl.remove();
             }, 4000);
@@ -238,16 +238,16 @@
             const text = document.getElementById('migrationsText');
             const spinner = document.getElementById('migrationsSpinner');
             const status = document.getElementById('migrationStatus');
-            
+
             btn.disabled = true;
             text.classList.add('hidden');
             spinner.classList.remove('hidden');
             status.textContent = 'Loading...';
-            
+
             try {
                 const response = await fetch('/__run_migrations__/');
                 const data = await response.json();
-                
+
                 if (data.status === 'success') {
                     showStatus('✓ Migrations completed successfully!', 'success');
                     status.textContent = '✓ Done';
@@ -273,16 +273,16 @@
             const text = document.getElementById('adminText');
             const spinner = document.getElementById('adminSpinner');
             const status = document.getElementById('adminStatus');
-            
+
             btn.disabled = true;
             text.classList.add('hidden');
             spinner.classList.remove('hidden');
             status.textContent = 'Loading...';
-            
+
             try {
                 const response = await fetch('/__create_admin__/');
                 const data = await response.json();
-                
+
                 if (data.status === 'success' || data.status === 'info') {
                     showStatus('✓ Admin user ready! Use admin / password', 'success');
                     status.textContent = '✓ Done';

--- a/packages/django-cf/templates/durable-objects/README.md
+++ b/packages/django-cf/templates/durable-objects/README.md
@@ -38,15 +38,15 @@ template-root/
 
 1.  **Install Dependencies:**
     Ensure you have Node.js, npm, and Python installed. Then:
-    
+
     ```bash
     # Install Node.js dependencies
     npm install
-    
+
     # Install Python dependencies
     uv sync
     ```
-    
+
     If you don't have `uv` installed, install it first:
     ```bash
     pip install uv

--- a/packages/django-cf/templates/durable-objects/src/app/asgi.py
+++ b/packages/django-cf/templates/durable-objects/src/app/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
 
 application = get_asgi_application()

--- a/packages/django-cf/templates/durable-objects/src/app/settings.py
+++ b/packages/django-cf/templates/durable-objects/src/app/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/5.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
+
 import os
 from pathlib import Path
 
@@ -20,70 +21,67 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-n+hxsvm6_5^5kx2xxe0@oq6@9laf0%&%)@du(pn6-(3enfoha_'
+SECRET_KEY = "django-insecure-n+hxsvm6_5^5kx2xxe0@oq6@9laf0%&%)@du(pn6-(3enfoha_"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
 
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-
-    'blog',
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "blog",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-ROOT_URLCONF = 'app.urls'
+ROOT_URLCONF = "app.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            BASE_DIR.joinpath('templates')
-        ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR.joinpath("templates")],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'app.wsgi.application'
+WSGI_APPLICATION = "app.wsgi.application"
 
 
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
 # Workers CI is missing the sqlite3 module, to build the staticfiles, we must disable the engine
-if os.getenv('WORKERS_CI') == "1":
+if os.getenv("WORKERS_CI") == "1":
     DATABASES = {}
 else:
     DATABASES = {
-        'default': {
-            'ENGINE': 'django_cf.db.backends.do',
+        "default": {
+            "ENGINE": "django_cf.db.backends.do",
         }
     }
 
@@ -92,16 +90,16 @@ else:
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
 
@@ -109,9 +107,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.1/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 # Enabling translations, requires also enabling the glob "vendor/**/*.mo" in wrangler.jsonc
 # This will make your worker bigger than 3MB, thus requiring you a Workers Paid Plan
@@ -123,10 +121,10 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
-STATIC_URL = 'static/'
-STATIC_ROOT = BASE_DIR.parent.joinpath('staticfiles').joinpath('static')
+STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR.parent.joinpath("staticfiles").joinpath("static")
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/packages/django-cf/templates/durable-objects/src/app/urls.py
+++ b/packages/django-cf/templates/durable-objects/src/app/urls.py
@@ -14,29 +14,37 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.contrib.auth import get_user_model
+from django.contrib.auth.decorators import user_passes_test
 from django.core.management import call_command
 from django.http import JsonResponse
-from django.urls import path, include
-from django.contrib.auth.decorators import user_passes_test
+from django.urls import include, path
+
 
 def is_superuser(user):
     return user.is_authenticated and user.is_superuser
 
+
 # @user_passes_test(is_superuser)
 def create_admin_view(request):
     User = get_user_model()
-    username = 'admin' # Or get from request, config, etc.
-    email = 'admin@example.com' # Or get from request, config, etc.
+    username = "admin"  # Or get from request, config, etc.
+    email = "admin@example.com"  # Or get from request, config, etc.
     # IMPORTANT: Change this password or manage it securely!
-    password = 'password'
+    password = "password"
 
     if not User.objects.filter(username=username).exists():
         User.objects.create_superuser(username, email, password)
-        return JsonResponse({"status": "success", "message": f"Admin user '{username}' created."})
+        return JsonResponse(
+            {"status": "success", "message": f"Admin user '{username}' created."}
+        )
     else:
-        return JsonResponse({"status": "info", "message": f"Admin user '{username}' already exists."})
+        return JsonResponse(
+            {"status": "info", "message": f"Admin user '{username}' already exists."}
+        )
+
 
 # @user_passes_test(is_superuser)
 def run_migrations_view(request):
@@ -48,10 +56,9 @@ def run_migrations_view(request):
 
 
 urlpatterns = [
-    path('', include('blog.urls')),
-
-    path('admin/', admin.site.urls),
+    path("", include("blog.urls")),
+    path("admin/", admin.site.urls),
     # Management endpoints - secure these appropriately for your application
-    path('__create_admin__/', create_admin_view, name='create_admin'),
-    path('__run_migrations__/', run_migrations_view, name='run_migrations'),
+    path("__create_admin__/", create_admin_view, name="create_admin"),
+    path("__run_migrations__/", run_migrations_view, name="run_migrations"),
 ]

--- a/packages/django-cf/templates/durable-objects/src/app/wsgi.py
+++ b/packages/django-cf/templates/durable-objects/src/app/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
 
 application = get_wsgi_application()

--- a/packages/django-cf/templates/durable-objects/src/blog/admin.py
+++ b/packages/django-cf/templates/durable-objects/src/blog/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from .models import Post
 
 admin.site.register(Post)

--- a/packages/django-cf/templates/durable-objects/src/blog/apps.py
+++ b/packages/django-cf/templates/durable-objects/src/blog/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class BlogConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'blog'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "blog"

--- a/packages/django-cf/templates/durable-objects/src/blog/migrations/0001_initial.py
+++ b/packages/django-cf/templates/durable-objects/src/blog/migrations/0001_initial.py
@@ -5,30 +5,36 @@ from django.db import migrations, models
 
 
 def insert_dummy_blog_post(apps, schema_editor):
-    Post = apps.get_model('blog', 'Post')
+    Post = apps.get_model("blog", "Post")
 
     # Insert the record
     Post.objects.create(
-        title='Example Post',
-        content="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+        title="Example Post",
+        content="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
     )
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
-            name='Post',
+            name="Post",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('title', models.CharField(max_length=200)),
-                ('content', models.TextField()),
-                ('pub_date', models.DateTimeField(default=django.utils.timezone.now)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("title", models.CharField(max_length=200)),
+                ("content", models.TextField()),
+                ("pub_date", models.DateTimeField(default=django.utils.timezone.now)),
             ],
         ),
         migrations.RunPython(

--- a/packages/django-cf/templates/durable-objects/src/blog/models.py
+++ b/packages/django-cf/templates/durable-objects/src/blog/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 
+
 class Post(models.Model):
     title = models.CharField(max_length=200)
     content = models.TextField()

--- a/packages/django-cf/templates/durable-objects/src/blog/urls.py
+++ b/packages/django-cf/templates/durable-objects/src/blog/urls.py
@@ -3,9 +3,9 @@ from django.views.generic import TemplateView
 
 from . import views
 
-app_name = 'blog'
+app_name = "blog"
 urlpatterns = [
-    path('', TemplateView.as_view(template_name='landing.html'), name='landing'),
-    path('blog/', views.post_list, name='post_list'),
-    path('blog/post/<int:pk>/', views.post_detail, name='post_detail'),
+    path("", TemplateView.as_view(template_name="landing.html"), name="landing"),
+    path("blog/", views.post_list, name="post_list"),
+    path("blog/post/<int:pk>/", views.post_detail, name="post_detail"),
 ]

--- a/packages/django-cf/templates/durable-objects/src/blog/views.py
+++ b/packages/django-cf/templates/durable-objects/src/blog/views.py
@@ -1,10 +1,13 @@
-from django.shortcuts import render, get_object_or_404
+from django.shortcuts import get_object_or_404, render
+
 from .models import Post
 
+
 def post_list(request):
-    posts = Post.objects.order_by('-pub_date')
-    return render(request, 'blog/post_list.html', {'posts': posts})
+    posts = Post.objects.order_by("-pub_date")
+    return render(request, "blog/post_list.html", {"posts": posts})
+
 
 def post_detail(request, pk):
     post = get_object_or_404(Post, pk=pk)
-    return render(request, 'blog/post_detail.html', {'post': post})
+    return render(request, "blog/post_detail.html", {"post": post})

--- a/packages/django-cf/templates/durable-objects/src/index.py
+++ b/packages/django-cf/templates/durable-objects/src/index.py
@@ -1,7 +1,7 @@
+from app.wsgi import application
 from workers import DurableObject, WorkerEntrypoint
 
 from django_cf import DjangoCFDurableObject
-from app.wsgi import application
 
 
 class DjangoDO(DjangoCFDurableObject, DurableObject):

--- a/packages/django-cf/templates/durable-objects/src/manage.py
+++ b/packages/django-cf/templates/durable-objects/src/manage.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -18,5 +19,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/packages/django-cf/templates/durable-objects/src/templates/blog/base.html
+++ b/packages/django-cf/templates/durable-objects/src/templates/blog/base.html
@@ -13,7 +13,7 @@
             -webkit-text-fill-color: transparent;
             background-clip: text;
         }
-        
+
         .glass-effect {
             background: rgba(255, 255, 255, 0.08);
             backdrop-filter: blur(10px);

--- a/packages/django-cf/templates/durable-objects/src/templates/landing.html
+++ b/packages/django-cf/templates/durable-objects/src/templates/landing.html
@@ -16,32 +16,32 @@
                 transform: translateY(0);
             }
         }
-        
+
         @keyframes spin {
             to { transform: rotate(360deg); }
         }
-        
+
         .animate-fade-in-up {
             animation: fadeInUp 0.6s ease forwards;
         }
-        
+
         .animate-spin-custom {
             animation: spin 1s linear infinite;
         }
-        
+
         .gradient-text {
             background: linear-gradient(135deg, #10b981 0%, #059669 100%);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
         }
-        
+
         .glass-effect {
             background: rgba(255, 255, 255, 0.08);
             backdrop-filter: blur(10px);
             border: 1px solid rgba(255, 255, 255, 0.1);
         }
-        
+
         .status-message {
             position: fixed;
             top: 20px;
@@ -50,7 +50,7 @@
             z-index: 50;
             animation: slideDown 0.3s ease;
         }
-        
+
         @keyframes slideDown {
             from {
                 opacity: 0;
@@ -220,14 +220,14 @@
             const container = document.getElementById('statusContainer');
             const bgColor = type === 'success' ? 'bg-emerald-500/20 border-emerald-500/50' : 'bg-red-500/20 border-red-500/50';
             const textColor = type === 'success' ? 'text-emerald-300' : 'text-red-300';
-            
+
             const statusEl = document.createElement('div');
             statusEl.className = `status-message glass-effect rounded-lg px-6 py-3 ${bgColor} ${textColor} font-semibold`;
             statusEl.textContent = message;
-            
+
             container.innerHTML = '';
             container.appendChild(statusEl);
-            
+
             setTimeout(() => {
                 statusEl.remove();
             }, 4000);
@@ -238,16 +238,16 @@
             const text = document.getElementById('migrationsText');
             const spinner = document.getElementById('migrationsSpinner');
             const status = document.getElementById('migrationStatus');
-            
+
             btn.disabled = true;
             text.classList.add('hidden');
             spinner.classList.remove('hidden');
             status.textContent = 'Loading...';
-            
+
             try {
                 const response = await fetch('/__run_migrations__/');
                 const data = await response.json();
-                
+
                 if (data.status === 'success') {
                     showStatus('✓ Migrations completed successfully!', 'success');
                     status.textContent = '✓ Done';
@@ -273,16 +273,16 @@
             const text = document.getElementById('adminText');
             const spinner = document.getElementById('adminSpinner');
             const status = document.getElementById('adminStatus');
-            
+
             btn.disabled = true;
             text.classList.add('hidden');
             spinner.classList.remove('hidden');
             status.textContent = 'Loading...';
-            
+
             try {
                 const response = await fetch('/__create_admin__/');
                 const data = await response.json();
-                
+
                 if (data.status === 'success' || data.status === 'info') {
                     showStatus('✓ Admin user ready! Use admin / password', 'success');
                     status.textContent = '✓ Done';

--- a/packages/django-cf/tests/d1/test_admin.py
+++ b/packages/django-cf/tests/d1/test_admin.py
@@ -1,6 +1,7 @@
 import requests
 
-from ..utils import d1_web_server  # NOQA
+from ..utils import d1_web_server  # noqa: F401
+
 
 def get_csrf_token(client, url):
     """Fetches a page and extracts the CSRF token from a form."""
@@ -42,6 +43,7 @@ def test_admin_login_page_loads(d1_web_server):
     assert response.status_code == 200
     assert "Django administration" in response.text
 
+
 def test_admin_dashboard_unauthorized_access(d1_web_server):
     """Test that accessing the admin dashboard without login redirects to the login page."""
     admin_dashboard_url = f"{d1_web_server.base_url}/admin/"
@@ -49,7 +51,9 @@ def test_admin_dashboard_unauthorized_access(d1_web_server):
 
     client = requests.Session()
     # First check with allow_redirects=False to see the 302
-    response_no_redirect = client.get(admin_dashboard_url, timeout=10, allow_redirects=False)
+    response_no_redirect = client.get(
+        admin_dashboard_url, timeout=10, allow_redirects=False
+    )
     assert response_no_redirect.status_code == 302
     location_header = response_no_redirect.headers.get("Location", "")
     # The location might be relative /admin/login/?next=/admin/ or absolute
@@ -59,8 +63,13 @@ def test_admin_dashboard_unauthorized_access(d1_web_server):
     # Then check with allow_redirects=True (default) to ensure it lands on the login page
     response_followed = client.get(admin_dashboard_url, timeout=10)
     assert response_followed.status_code == 200
-    assert response_followed.url.startswith(login_url) # Final URL should be the login page
-    assert "Django administration" in response_followed.text # Should show the login page content
+    assert response_followed.url.startswith(
+        login_url
+    )  # Final URL should be the login page
+    assert (
+        "Django administration" in response_followed.text
+    )  # Should show the login page content
+
 
 def test_admin_login_successful(d1_web_server):
     """Test a successful login to the Django admin."""
@@ -79,7 +88,7 @@ def test_admin_login_successful(d1_web_server):
     response = client.post(login_url, data=login_data, headers=headers, timeout=10)
 
     assert response.status_code == 200
-    assert response.url.rstrip('/') == admin_dashboard_url.rstrip('/')
+    assert response.url.rstrip("/") == admin_dashboard_url.rstrip("/")
     assert "Site administration" in response.text
     assert "Log out" in response.text
 
@@ -102,6 +111,7 @@ def test_admin_login_failed_wrong_password(d1_web_server):
     assert "Please enter the correct username and password" in response.text
     assert "Log out" not in response.text
 
+
 def test_admin_login_failed_wrong_username(d1_web_server):
     """Test a failed login attempt with a non-existent username."""
     login_url = f"{d1_web_server.base_url}/admin/login/"
@@ -120,6 +130,7 @@ def test_admin_login_failed_wrong_username(d1_web_server):
     assert "Please enter the correct username and password" in response.text
     assert "Log out" not in response.text
 
+
 def test_admin_logout(d1_web_server):
     """Test logging out from the Django admin."""
     login_url = f"{d1_web_server.base_url}/admin/login/"
@@ -136,9 +147,11 @@ def test_admin_logout(d1_web_server):
         "next": "/admin/",
     }
     headers_login = {"Referer": login_url}
-    response_login = client.post(login_url, data=login_data, headers=headers_login, timeout=10)
+    response_login = client.post(
+        login_url, data=login_data, headers=headers_login, timeout=10
+    )
     assert response_login.status_code == 200
-    assert response_login.url.rstrip('/') == admin_dashboard_url.rstrip('/')
+    assert response_login.url.rstrip("/") == admin_dashboard_url.rstrip("/")
     assert "Log out" in response_login.text
 
     # 2. Logout
@@ -160,22 +173,34 @@ def test_admin_logout(d1_web_server):
 
     csrf_token_logout = get_csrf_token(client, admin_dashboard_url)
 
-    headers_logout = {"Referer": admin_dashboard_url} # Referer should be the page from which the POST is made
-    response_logout = client.post(logout_url, data={"csrfmiddlewaretoken": csrf_token_logout}, headers=headers_logout, timeout=10)
+    headers_logout = {
+        "Referer": admin_dashboard_url
+    }  # Referer should be the page from which the POST is made
+    response_logout = client.post(
+        logout_url,
+        data={"csrfmiddlewaretoken": csrf_token_logout},
+        headers=headers_logout,
+        timeout=10,
+    )
 
     # After a successful POST to /admin/logout/, Django typically redirects to the login page.
     # The status code of the POST response itself might be 200 (if it renders a "Logged out" page)
     # or 302 (if it immediately redirects). We should check the content of the page it lands on.
     # If it's 302, the client will follow it if allow_redirects is True (default for client.post).
 
-    assert response_logout.status_code == 200 # Django's default logout view returns 200
+    assert (
+        response_logout.status_code == 200
+    )  # Django's default logout view returns 200
     # Check for text that appears on the "Logged out" confirmation page, which is often the login page with a message.
     # For Django < 4.0, it's "Logged out". For Django 4.0+, it's "Logged out". Django 5.0 shows "Log in again" on the login page.
-    assert "Logged out" in response_logout.text or "Log in again" in response_logout.text
-
+    assert (
+        "Logged out" in response_logout.text or "Log in again" in response_logout.text
+    )
 
     # 3. Verify user is logged out by trying to access an authenticated page
-    response_dashboard_after_logout = client.get(admin_dashboard_url, timeout=10, allow_redirects=True) # allow_redirects is True by default for GET too
+    response_dashboard_after_logout = client.get(
+        admin_dashboard_url, timeout=10, allow_redirects=True
+    )  # allow_redirects is True by default for GET too
     assert response_dashboard_after_logout.status_code == 200
     assert response_dashboard_after_logout.url.startswith(login_url)
     assert "Django administration" in response_dashboard_after_logout.text

--- a/packages/django-cf/tests/d1/test_worker.py
+++ b/packages/django-cf/tests/d1/test_worker.py
@@ -1,6 +1,7 @@
 import requests
 
-from ..utils import d1_web_server  # NOQA
+from ..utils import d1_web_server  # noqa: F401
+
 
 def test_migrations(d1_web_server):
     """Run migrations."""
@@ -8,9 +9,12 @@ def test_migrations(d1_web_server):
     assert response.status_code == 200
     assert response.json() == {"status": "success", "message": "Migrations applied."}
 
+
 def test_create_admin(d1_web_server):
     """Create an admin user a second time should return different state."""
     response = requests.get(f"{d1_web_server.base_url}/__create_admin__/")
     assert response.status_code == 200
-    assert response.json() == {"status": "info", "message": f"Admin user 'admin' already exists."}
-
+    assert response.json() == {
+        "status": "info",
+        "message": "Admin user 'admin' already exists.",
+    }

--- a/packages/django-cf/tests/db/test_base_engine.py
+++ b/packages/django-cf/tests/db/test_base_engine.py
@@ -1,7 +1,9 @@
 """Tests for django_cf/db/base_engine.py - Core database functionality."""
-import pytest
+
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 class TestCFResult:
@@ -11,7 +13,7 @@ class TestCFResult:
         """Test CFResult initialization."""
         from django_cf.db.base_engine import CFResult
 
-        data = [(1, 'a'), (2, 'b'), (3, 'c')]
+        data = [(1, "a"), (2, "b"), (3, "c")]
         result = CFResult(data)
 
         assert result.data == data
@@ -22,11 +24,11 @@ class TestCFResult:
         """Test CFResult iteration."""
         from django_cf.db.base_engine import CFResult
 
-        data = [(1, 'a'), (2, 'b')]
+        data = [(1, "a"), (2, "b")]
         result = CFResult(data)
 
         items = list(result)
-        assert items == [(1, 'a'), (2, 'b')]
+        assert items == [(1, "a"), (2, "b")]
 
     def test_set_lastrowid(self):
         """Test setting lastrowid."""
@@ -50,11 +52,11 @@ class TestCFResult:
         """Test fetchone returns and removes last item."""
         from django_cf.db.base_engine import CFResult
 
-        data = [(1, 'a'), (2, 'b'), (3, 'c')]
+        data = [(1, "a"), (2, "b"), (3, "c")]
         result = CFResult(data)
 
         row = result.fetchone()
-        assert row == (3, 'c')
+        assert row == (3, "c")
         assert len(result.data) == 2
 
     def test_fetchone_empty(self):
@@ -70,12 +72,12 @@ class TestCFResult:
         """Test fetchall returns all rows."""
         from django_cf.db.base_engine import CFResult
 
-        data = [(1, 'a'), (2, 'b'), (3, 'c')]
+        data = [(1, "a"), (2, "b"), (3, "c")]
         result = CFResult(data)
 
         rows = result.fetchall()
         # Note: fetchall uses fetchone which pops from end, so order is reversed
-        assert rows == [(3, 'c'), (2, 'b'), (1, 'a')]
+        assert rows == [(3, "c"), (2, "b"), (1, "a")]
         assert len(result.data) == 0
 
     def test_fetchall_empty(self):
@@ -91,18 +93,18 @@ class TestCFResult:
         """Test fetchmany with default size=1."""
         from django_cf.db.base_engine import CFResult
 
-        data = [(1, 'a'), (2, 'b'), (3, 'c')]
+        data = [(1, "a"), (2, "b"), (3, "c")]
         result = CFResult(data)
 
         rows = result.fetchmany()
-        assert rows == [(3, 'c')]
+        assert rows == [(3, "c")]
         assert len(result.data) == 2
 
     def test_fetchmany_specific_size(self):
         """Test fetchmany with specific size."""
         from django_cf.db.base_engine import CFResult
 
-        data = [(1, 'a'), (2, 'b'), (3, 'c')]
+        data = [(1, "a"), (2, "b"), (3, "c")]
         result = CFResult(data)
 
         rows = result.fetchmany(2)
@@ -113,7 +115,7 @@ class TestCFResult:
         """Test fetchmany when requesting more than available."""
         from django_cf.db.base_engine import CFResult
 
-        data = [(1, 'a'), (2, 'b')]
+        data = [(1, "a"), (2, "b")]
         result = CFResult(data)
 
         rows = result.fetchmany(5)
@@ -124,20 +126,20 @@ class TestCFResult:
         """Test from_object with list-style row data."""
         from django_cf.db.base_engine import CFResult
 
-        data = [[1, 'hello', True], [2, 'world', False]]
-        result = CFResult.from_object('SELECT * FROM test', None, data)
+        data = [[1, "hello", True], [2, "world", False]]
+        result = CFResult.from_object("SELECT * FROM test", None, data)
 
         rows = list(result)
         assert len(rows) == 2
-        assert rows[0] == (1, 'hello', True)
-        assert rows[1] == (2, 'world', False)
+        assert rows[0] == (1, "hello", True)
+        assert rows[1] == (2, "world", False)
 
     def test_from_object_with_dict_rows(self):
         """Test from_object with dict-style row data."""
         from django_cf.db.base_engine import CFResult
 
-        data = [{'id': 1, 'name': 'hello'}, {'id': 2, 'name': 'world'}]
-        result = CFResult.from_object('SELECT * FROM test', None, data)
+        data = [{"id": 1, "name": "hello"}, {"id": 2, "name": "world"}]
+        result = CFResult.from_object("SELECT * FROM test", None, data)
 
         rows = list(result)
         assert len(rows) == 2
@@ -147,11 +149,7 @@ class TestCFResult:
         from django_cf.db.base_engine import CFResult
 
         result = CFResult.from_object(
-            'INSERT INTO test VALUES (1)',
-            None,
-            [],
-            rows_read=0,
-            rows_written=5
+            "INSERT INTO test VALUES (1)", None, [], rows_read=0, rows_written=5
         )
 
         assert result.rowcount == 5
@@ -161,11 +159,7 @@ class TestCFResult:
         from django_cf.db.base_engine import CFResult
 
         result = CFResult.from_object(
-            'UPDATE test SET name = "new"',
-            None,
-            [],
-            rows_read=0,
-            rows_written=3
+            'UPDATE test SET name = "new"', None, [], rows_read=0, rows_written=3
         )
 
         assert result.rowcount == 3
@@ -175,11 +169,7 @@ class TestCFResult:
         from django_cf.db.base_engine import CFResult
 
         result = CFResult.from_object(
-            'DELETE FROM test WHERE id = 1',
-            None,
-            [],
-            rows_read=0,
-            rows_written=2
+            "DELETE FROM test WHERE id = 1", None, [], rows_read=0, rows_written=2
         )
 
         assert result.rowcount == 2
@@ -189,11 +179,11 @@ class TestCFResult:
         from django_cf.db.base_engine import CFResult
 
         result = CFResult.from_object(
-            'SELECT * FROM test',
+            "SELECT * FROM test",
             None,
             [[1], [2], [3]],  # List-style rows, not tuples
             rows_read=3,
-            rows_written=0
+            rows_written=0,
         )
 
         assert result.rowcount == 3
@@ -203,10 +193,7 @@ class TestCFResult:
         from django_cf.db.base_engine import CFResult
 
         result = CFResult.from_object(
-            'INSERT INTO test VALUES (1)',
-            None,
-            [],
-            last_row_id=42
+            "INSERT INTO test VALUES (1)", None, [], last_row_id=42
         )
 
         assert result.lastrowid == 42
@@ -219,9 +206,9 @@ class TestIsReadOnlyQuery:
         """Test SELECT queries are read-only."""
         from django_cf.db.base_engine import is_read_only_query
 
-        assert is_read_only_query('SELECT * FROM users') is True
-        assert is_read_only_query('  SELECT id FROM users WHERE id = 1') is True
-        assert is_read_only_query('select * from users') is True
+        assert is_read_only_query("SELECT * FROM users") is True
+        assert is_read_only_query("  SELECT id FROM users WHERE id = 1") is True
+        assert is_read_only_query("select * from users") is True
 
     def test_insert_query(self):
         """Test INSERT queries are not read-only."""
@@ -239,38 +226,41 @@ class TestIsReadOnlyQuery:
         """Test DELETE queries are not read-only."""
         from django_cf.db.base_engine import is_read_only_query
 
-        assert is_read_only_query('DELETE FROM users WHERE id = 1') is False
+        assert is_read_only_query("DELETE FROM users WHERE id = 1") is False
 
     def test_create_table_query(self):
         """Test CREATE TABLE queries are not read-only."""
         from django_cf.db.base_engine import is_read_only_query
 
-        assert is_read_only_query('CREATE TABLE users (id INT)') is False
+        assert is_read_only_query("CREATE TABLE users (id INT)") is False
 
     def test_alter_table_query(self):
         """Test ALTER TABLE queries are not read-only."""
         from django_cf.db.base_engine import is_read_only_query
 
-        assert is_read_only_query('ALTER TABLE users ADD COLUMN email TEXT') is False
+        assert is_read_only_query("ALTER TABLE users ADD COLUMN email TEXT") is False
 
     def test_drop_table_query(self):
         """Test DROP TABLE queries are not read-only."""
         from django_cf.db.base_engine import is_read_only_query
 
-        assert is_read_only_query('DROP TABLE users') is False
+        assert is_read_only_query("DROP TABLE users") is False
 
     def test_replace_query(self):
         """Test REPLACE queries are not read-only."""
         from django_cf.db.base_engine import is_read_only_query
 
-        assert is_read_only_query('REPLACE INTO users (id, name) VALUES (1, "test")') is False
+        assert (
+            is_read_only_query('REPLACE INTO users (id, name) VALUES (1, "test")')
+            is False
+        )
 
     def test_empty_query(self):
         """Test empty query returns False."""
         from django_cf.db.base_engine import is_read_only_query
 
-        assert is_read_only_query('') is False
-        assert is_read_only_query('   ') is False
+        assert is_read_only_query("") is False
+        assert is_read_only_query("   ") is False
 
 
 class TestReplaceDateTruncInSql:
@@ -289,66 +279,66 @@ class TestReplaceDateTruncInSql:
         """Test django_date_trunc is replaced with CASE statement."""
         from django_cf.db.base_engine import replace_date_trunc_in_sql
 
-        sql = 'SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders'
+        sql = "SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders"
         result = replace_date_trunc_in_sql(sql)
 
         # Should contain CASE statement with STRFTIME
-        assert 'CASE %s' in result
-        assert 'STRFTIME' in result
-        assert 'django_date_trunc' not in result
+        assert "CASE %s" in result
+        assert "STRFTIME" in result
+        assert "django_date_trunc" not in result
 
     def test_django_datetime_trunc_replacement(self):
         """Test django_datetime_trunc is replaced with CASE statement."""
         from django_cf.db.base_engine import replace_date_trunc_in_sql
 
-        sql = 'SELECT django_datetime_trunc(%s, created_at, %s, %s) FROM orders'
+        sql = "SELECT django_datetime_trunc(%s, created_at, %s, %s) FROM orders"
         result = replace_date_trunc_in_sql(sql)
 
         # Should contain CASE statement
-        assert 'CASE %s' in result
-        assert 'django_datetime_trunc' not in result
+        assert "CASE %s" in result
+        assert "django_datetime_trunc" not in result
 
     def test_year_truncation_in_case(self):
         """Test year truncation template is in result."""
         from django_cf.db.base_engine import replace_date_trunc_in_sql
 
-        sql = 'SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders'
+        sql = "SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders"
         result = replace_date_trunc_in_sql(sql)
 
         assert "WHEN 'year'" in result
-        assert '%Y-01-01' in result
+        assert "%Y-01-01" in result
 
     def test_month_truncation_in_case(self):
         """Test month truncation template is in result."""
         from django_cf.db.base_engine import replace_date_trunc_in_sql
 
-        sql = 'SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders'
+        sql = "SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders"
         result = replace_date_trunc_in_sql(sql)
 
         assert "WHEN 'month'" in result
-        assert '%Y-%m-01' in result
+        assert "%Y-%m-01" in result
 
     def test_day_truncation_in_case(self):
         """Test day truncation template is in result."""
         from django_cf.db.base_engine import replace_date_trunc_in_sql
 
-        sql = 'SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders'
+        sql = "SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders"
         result = replace_date_trunc_in_sql(sql)
 
         assert "WHEN 'day'" in result
-        assert 'DATE(created_at)' in result
+        assert "DATE(created_at)" in result
 
     def test_multiple_date_truncs(self):
         """Test multiple django_date_trunc calls are replaced."""
         from django_cf.db.base_engine import replace_date_trunc_in_sql
 
-        sql = '''SELECT django_date_trunc(%s, created_at, %s, %s),
-                        django_date_trunc(%s, updated_at, %s, %s) FROM orders'''
+        sql = """SELECT django_date_trunc(%s, created_at, %s, %s),
+                        django_date_trunc(%s, updated_at, %s, %s) FROM orders"""
         result = replace_date_trunc_in_sql(sql)
 
-        assert 'django_date_trunc' not in result
+        assert "django_date_trunc" not in result
         # Should have multiple CASE statements
-        assert result.count('CASE %s') == 2
+        assert result.count("CASE %s") == 2
 
 
 class TestCFDatabase:
@@ -420,7 +410,7 @@ class TestCFDatabase:
         mock_wrapper.run_query.return_value = CFResult([])
 
         db = CFDatabase(mock_wrapper)
-        db.execute('INSERT INTO test VALUES (%s)', (True,))
+        db.execute("INSERT INTO test VALUES (%s)", (True,))
 
         # Check that True was converted to 1
         call_args = mock_wrapper.run_query.call_args
@@ -434,7 +424,7 @@ class TestCFDatabase:
         mock_wrapper.run_query.return_value = CFResult([])
 
         db = CFDatabase(mock_wrapper)
-        db.execute('INSERT INTO test VALUES (%s)', (False,))
+        db.execute("INSERT INTO test VALUES (%s)", (False,))
 
         # Check that False was converted to 0
         call_args = mock_wrapper.run_query.call_args
@@ -448,11 +438,11 @@ class TestCFDatabase:
         mock_wrapper.run_query.return_value = CFResult([])
 
         db = CFDatabase(mock_wrapper)
-        db.execute('INSERT INTO test VALUES (%s)', (Decimal('10.5'),))
+        db.execute("INSERT INTO test VALUES (%s)", (Decimal("10.5"),))
 
         # Check that Decimal was converted to string
         call_args = mock_wrapper.run_query.call_args
-        assert call_args[0][1] == ('10.5',)
+        assert call_args[0][1] == ("10.5",)
 
     def test_execute_no_params(self):
         """Test execute with no parameters."""
@@ -462,10 +452,10 @@ class TestCFDatabase:
         mock_wrapper.run_query.return_value = CFResult([])
 
         db = CFDatabase(mock_wrapper)
-        db.execute('SELECT * FROM test')
+        db.execute("SELECT * FROM test")
 
         call_args = mock_wrapper.run_query.call_args
-        assert call_args[0][0] == 'SELECT * FROM test'
+        assert call_args[0][0] == "SELECT * FROM test"
         assert call_args[0][1] is None
 
     def test_fetchone_delegates_to_result(self):
@@ -473,25 +463,25 @@ class TestCFDatabase:
         from django_cf.db.base_engine import CFDatabase, CFResult
 
         mock_wrapper = MagicMock()
-        mock_result = CFResult([(1, 'test')])
+        mock_result = CFResult([(1, "test")])
         mock_wrapper.run_query.return_value = mock_result
 
         db = CFDatabase(mock_wrapper)
-        db.execute('SELECT * FROM test')
+        db.execute("SELECT * FROM test")
         row = db.fetchone()
 
-        assert row == (1, 'test')
+        assert row == (1, "test")
 
     def test_fetchall_delegates_to_result(self):
         """Test fetchall delegates to lastResult."""
         from django_cf.db.base_engine import CFDatabase, CFResult
 
         mock_wrapper = MagicMock()
-        mock_result = CFResult([(1, 'a'), (2, 'b')])
+        mock_result = CFResult([(1, "a"), (2, "b")])
         mock_wrapper.run_query.return_value = mock_result
 
         db = CFDatabase(mock_wrapper)
-        db.execute('SELECT * FROM test')
+        db.execute("SELECT * FROM test")
         rows = db.fetchall()
 
         assert len(rows) == 2
@@ -506,7 +496,7 @@ class TestCFDatabase:
         mock_wrapper.run_query.return_value = mock_result
 
         db = CFDatabase(mock_wrapper)
-        db.execute('INSERT INTO test VALUES (1)')
+        db.execute("INSERT INTO test VALUES (1)")
 
         assert db.lastrowid == 42
 
@@ -584,7 +574,7 @@ class TestCFDatabaseWrapper:
         """Test get_database_version returns tuple."""
         from django_cf.db.base_engine import CFDatabaseWrapper
 
-        with patch.object(CFDatabaseWrapper, '__init__', lambda x, *args: None):
+        with patch.object(CFDatabaseWrapper, "__init__", lambda x, *args: None):
             wrapper = CFDatabaseWrapper.__new__(CFDatabaseWrapper)
             version = wrapper.get_database_version()
 
@@ -594,7 +584,7 @@ class TestCFDatabaseWrapper:
         """Test close() is a no-op."""
         from django_cf.db.base_engine import CFDatabaseWrapper
 
-        with patch.object(CFDatabaseWrapper, '__init__', lambda x, *args: None):
+        with patch.object(CFDatabaseWrapper, "__init__", lambda x, *args: None):
             wrapper = CFDatabaseWrapper.__new__(CFDatabaseWrapper)
             result = wrapper.close()
 
@@ -604,7 +594,7 @@ class TestCFDatabaseWrapper:
         """Test _savepoint_allowed returns False."""
         from django_cf.db.base_engine import CFDatabaseWrapper
 
-        with patch.object(CFDatabaseWrapper, '__init__', lambda x, *args: None):
+        with patch.object(CFDatabaseWrapper, "__init__", lambda x, *args: None):
             wrapper = CFDatabaseWrapper.__new__(CFDatabaseWrapper)
             result = wrapper._savepoint_allowed()
 
@@ -614,7 +604,7 @@ class TestCFDatabaseWrapper:
         """Test is_usable always returns True."""
         from django_cf.db.base_engine import CFDatabaseWrapper
 
-        with patch.object(CFDatabaseWrapper, '__init__', lambda x, *args: None):
+        with patch.object(CFDatabaseWrapper, "__init__", lambda x, *args: None):
             wrapper = CFDatabaseWrapper.__new__(CFDatabaseWrapper)
             result = wrapper.is_usable()
 
@@ -624,11 +614,11 @@ class TestCFDatabaseWrapper:
         """Test run_query raises NotImplementedError."""
         from django_cf.db.base_engine import CFDatabaseWrapper
 
-        with patch.object(CFDatabaseWrapper, '__init__', lambda x, *args: None):
+        with patch.object(CFDatabaseWrapper, "__init__", lambda x, *args: None):
             wrapper = CFDatabaseWrapper.__new__(CFDatabaseWrapper)
 
             with pytest.raises(NotImplementedError):
-                wrapper.run_query('SELECT 1')
+                wrapper.run_query("SELECT 1")
 
 
 class TestCFDatabaseOperations:
@@ -641,12 +631,12 @@ class TestCFDatabaseOperations:
         mock_wrapper = MagicMock()
         ops = CFDatabaseOperations(mock_wrapper)
 
-        fields = ['id', 'name']
-        placeholder_rows = [('%s', '%s'), ('%s', '%s')]
+        fields = ["id", "name"]
+        placeholder_rows = [("%s", "%s"), ("%s", "%s")]
 
         result = ops.bulk_insert_sql(fields, placeholder_rows)
 
-        assert result == 'VALUES (%s, %s), (%s, %s)'
+        assert result == "VALUES (%s, %s), (%s, %s)"
 
     def test_last_executed_query_no_params(self):
         """Test last_executed_query with no parameters."""
@@ -655,7 +645,7 @@ class TestCFDatabaseOperations:
         mock_wrapper = MagicMock()
         ops = CFDatabaseOperations(mock_wrapper)
 
-        sql = 'SELECT * FROM test'
+        sql = "SELECT * FROM test"
         result = ops.last_executed_query(None, sql, None)
 
         assert result == sql
@@ -670,14 +660,14 @@ class TestCFDatabaseOperations:
         mock_wrapper.connection.cursor.return_value = mock_cursor
         ops = CFDatabaseOperations(mock_wrapper)
 
-        sql = 'SELECT * FROM test WHERE id = %s'
+        sql = "SELECT * FROM test WHERE id = %s"
         # The actual result depends on _quote_params_for_last_executed_query
         # which may return None, causing substitution to either work or fall back
         result = ops.last_executed_query(None, sql, [1])
 
         # Result should be a string (either substituted or original)
         assert isinstance(result, str)
-        assert 'SELECT * FROM test WHERE id' in result
+        assert "SELECT * FROM test WHERE id" in result
 
     def test_last_executed_query_catches_formatting_errors(self):
         """Test last_executed_query catches Exception on format failure."""
@@ -687,7 +677,7 @@ class TestCFDatabaseOperations:
         ops = CFDatabaseOperations(mock_wrapper)
 
         # Mismatched format string and params to trigger formatting error
-        sql = 'SELECT * FROM test WHERE id = %s AND name = %s'
+        sql = "SELECT * FROM test WHERE id = %s AND name = %s"
         params = (1,)  # Too few params for the format string
 
         result = ops.last_executed_query(None, sql, params)
@@ -706,13 +696,14 @@ class TestCFDatabaseOperations:
         class BadStr:
             def __str__(self):
                 raise KeyboardInterrupt()
+
             def __format__(self, spec):
                 raise KeyboardInterrupt()
 
         # Patch _quote_params to return a tuple with our bad object
         ops._quote_params_for_last_executed_query = lambda params: (BadStr(),)
 
-        sql = 'SELECT * FROM test WHERE id = %s'
+        sql = "SELECT * FROM test WHERE id = %s"
 
         with pytest.raises(KeyboardInterrupt):
             ops.last_executed_query(None, sql, [1])
@@ -731,7 +722,7 @@ class TestCFSQLCompiler:
         result = compiler._replace_date_trunc_functions(sql)
 
         assert 'STRFTIME("%Y-01-01", created_at)' in result
-        assert 'django_date_trunc' not in result
+        assert "django_date_trunc" not in result
 
     def test_replace_date_trunc_functions_month(self):
         """Test _replace_date_trunc_functions for month truncation."""
@@ -753,7 +744,7 @@ class TestCFSQLCompiler:
         sql = "SELECT django_date_trunc('day', created_at) FROM orders"
         result = compiler._replace_date_trunc_functions(sql)
 
-        assert 'DATE(created_at)' in result
+        assert "DATE(created_at)" in result
 
     def test_replace_date_trunc_functions_hour(self):
         """Test _replace_date_trunc_functions for hour truncation."""

--- a/packages/django-cf/tests/db/test_d1_backend.py
+++ b/packages/django-cf/tests/db/test_d1_backend.py
@@ -1,7 +1,9 @@
 """Tests for django_cf/db/backends/d1/base.py - D1 database backend."""
-import pytest
-from unittest.mock import MagicMock, patch, PropertyMock
+
 import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 class TestD1DatabaseWrapperProcessQuery:
@@ -13,10 +15,10 @@ class TestD1DatabaseWrapperProcessQuery:
         mock_workers = MagicMock()
         mock_run_sync = MagicMock()
 
-        with patch.dict(sys.modules, {
-            'workers': mock_workers,
-            'pyodide.ffi': MagicMock(run_sync=mock_run_sync)
-        }):
+        with patch.dict(
+            sys.modules,
+            {"workers": mock_workers, "pyodide.ffi": MagicMock(run_sync=mock_run_sync)},
+        ):
             # Create a mock wrapper that mimics D1 DatabaseWrapper
             class MockD1Wrapper:
                 def __init__(self):
@@ -35,25 +37,25 @@ class TestD1DatabaseWrapperProcessQuery:
                     query = replace_date_trunc_in_sql(query)
 
                     if params is None:
-                        query = query.replace('%s', '?')
+                        query = query.replace("%s", "?")
                     else:
                         new_params = []
                         for param in params:
                             if param is None:
-                                query = query.replace('%s', 'null', 1)
+                                query = query.replace("%s", "null", 1)
                             else:
                                 new_params.append(param)
-                                query = query.replace('%s', '?', 1)
+                                query = query.replace("%s", "?", 1)
                         params = new_params
 
                     if self.cursor()._defer_foreign_keys:
-                        return f'''
+                        return f"""
                         PRAGMA defer_foreign_keys = on
 
                         {query}
 
                         PRAGMA defer_foreign_keys = off
-                        '''
+                        """
 
                     return query, params
 
@@ -63,85 +65,85 @@ class TestD1DatabaseWrapperProcessQuery:
         """Test process_query replaces %s with ? when no params."""
         wrapper = self._create_mock_wrapper()
 
-        query = 'SELECT * FROM users WHERE id = %s'
+        query = "SELECT * FROM users WHERE id = %s"
         result_query, result_params = wrapper.process_query(query, None)
 
-        assert result_query == 'SELECT * FROM users WHERE id = ?'
+        assert result_query == "SELECT * FROM users WHERE id = ?"
         assert result_params is None
 
     def test_process_query_with_params(self):
         """Test process_query replaces %s with ? for each param."""
         wrapper = self._create_mock_wrapper()
 
-        query = 'SELECT * FROM users WHERE id = %s AND name = %s'
-        params = [1, 'test']
+        query = "SELECT * FROM users WHERE id = %s AND name = %s"
+        params = [1, "test"]
         result_query, result_params = wrapper.process_query(query, params)
 
-        assert result_query == 'SELECT * FROM users WHERE id = ? AND name = ?'
-        assert result_params == [1, 'test']
+        assert result_query == "SELECT * FROM users WHERE id = ? AND name = ?"
+        assert result_params == [1, "test"]
 
     def test_process_query_null_param_replaced_with_literal(self):
         """Test process_query replaces None params with literal 'null'."""
         wrapper = self._create_mock_wrapper()
 
-        query = 'INSERT INTO users (name, email) VALUES (%s, %s)'
-        params = ['test', None]
+        query = "INSERT INTO users (name, email) VALUES (%s, %s)"
+        params = ["test", None]
         result_query, result_params = wrapper.process_query(query, params)
 
         # None should be replaced with literal 'null', not ?
-        assert 'null' in result_query
-        assert result_params == ['test']
+        assert "null" in result_query
+        assert result_params == ["test"]
 
     def test_process_query_all_null_params(self):
         """Test process_query when all params are None."""
         wrapper = self._create_mock_wrapper()
 
-        query = 'INSERT INTO users (name, email) VALUES (%s, %s)'
+        query = "INSERT INTO users (name, email) VALUES (%s, %s)"
         params = [None, None]
         result_query, result_params = wrapper.process_query(query, params)
 
-        assert result_query == 'INSERT INTO users (name, email) VALUES (null, null)'
+        assert result_query == "INSERT INTO users (name, email) VALUES (null, null)"
         assert result_params == []
 
     def test_process_query_mixed_params(self):
         """Test process_query with mixed None and non-None params."""
         wrapper = self._create_mock_wrapper()
 
-        query = 'UPDATE users SET name = %s, email = %s, age = %s WHERE id = %s'
-        params = ['test', None, 25, None]
+        query = "UPDATE users SET name = %s, email = %s, age = %s WHERE id = %s"
+        params = ["test", None, 25, None]
         result_query, result_params = wrapper.process_query(query, params)
 
-        assert result_params == ['test', 25]
+        assert result_params == ["test", 25]
         # Count ? marks - should be 2 (for 'test' and 25)
-        assert result_query.count('?') == 2
+        assert result_query.count("?") == 2
         # Count null literals - should be 2
-        assert result_query.count('null') == 2
+        assert result_query.count("null") == 2
 
     def test_process_query_with_defer_foreign_keys(self):
         """Test process_query adds PRAGMA when _defer_foreign_keys is True."""
         wrapper = self._create_mock_wrapper()
         wrapper._cursor_mock._defer_foreign_keys = True
 
-        query = 'INSERT INTO users (name) VALUES (%s)'
-        params = ['test']
+        query = "INSERT INTO users (name) VALUES (%s)"
+        params = ["test"]
         result = wrapper.process_query(query, params)
 
         # When defer_foreign_keys is True, returns string (not tuple)
         # This is actually a bug in the implementation
-        assert 'PRAGMA defer_foreign_keys = on' in result
-        assert 'PRAGMA defer_foreign_keys = off' in result
+        assert "PRAGMA defer_foreign_keys = on" in result
+        assert "PRAGMA defer_foreign_keys = off" in result
 
     def test_process_query_date_trunc_replacement(self):
         """Test process_query replaces django_date_trunc calls."""
         wrapper = self._create_mock_wrapper()
 
-        query = 'SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders'
-        params = ['year', 'UTC', 'UTC']
+        query = "SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders"
+        params = ["year", "UTC", "UTC"]
         result_query, result_params = wrapper.process_query(query, params)
 
         # Date trunc should be replaced
-        assert 'django_date_trunc' not in result_query
-        assert 'CASE' in result_query or 'STRFTIME' in result_query
+        assert "django_date_trunc" not in result_query
+        assert "CASE" in result_query or "STRFTIME" in result_query
 
 
 class TestD1DatabaseWrapperConfiguration:
@@ -152,14 +154,16 @@ class TestD1DatabaseWrapperConfiguration:
         # We can't fully import without worker environment,
         # but we can check the class definition
         import importlib.util
-        spec = importlib.util.find_spec('django_cf.db.backends.d1.base')
+
+        spec = importlib.util.find_spec("django_cf.db.backends.d1.base")
         assert spec is not None
 
     def test_display_name(self):
         """Test display name is 'D1'."""
         # Read the source to verify the display_name
         import importlib.util
-        spec = importlib.util.find_spec('django_cf.db.backends.d1.base')
+
+        spec = importlib.util.find_spec("django_cf.db.backends.d1.base")
         with open(spec.origin) as f:
             content = f.read()
             assert 'display_name = "D1"' in content
@@ -200,6 +204,7 @@ class TestD1GetConnectionParams:
             def get_connection_params(self):
                 if not self.settings_dict["CLOUDFLARE_BINDING"]:
                     from django.core.exceptions import ImproperlyConfigured
+
                     raise ImproperlyConfigured(
                         "settings.DATABASES is improperly configured. "
                         "Please supply the CLOUDFLARE_BINDING value."
@@ -222,18 +227,18 @@ class TestD1ExceptionHandling:
         and SystemExit, which should be allowed to propagate normally.
         """
         import importlib.util
-        spec = importlib.util.find_spec('django_cf.db.backends.d1.base')
+
+        spec = importlib.util.find_spec("django_cf.db.backends.d1.base")
         with open(spec.origin) as f:
             content = f.read()
             # Should use 'except Exception:' not bare 'except:'
-            assert 'except Exception:' in content
+            assert "except Exception:" in content
             # Should NOT have bare except (except inside 'except Exception')
-            lines = content.split('\n')
+            lines = content.split("\n")
             for line in lines:
                 stripped = line.strip()
-                if stripped.startswith('except') and stripped.endswith(':'):
-                    assert stripped != 'except:', \
-                        f"Found bare 'except:' clause: {line}"
+                if stripped.startswith("except") and stripped.endswith(":"):
+                    assert stripped != "except:", f"Found bare 'except:' clause: {line}"
 
 
 class TestD1ParameterHandling:
@@ -241,93 +246,97 @@ class TestD1ParameterHandling:
 
     def test_empty_params_list(self):
         """Test handling of empty params list."""
+
         # Create minimal process_query implementation
         def process_query(query, params=None):
             if params is None:
-                query = query.replace('%s', '?')
+                query = query.replace("%s", "?")
             else:
                 new_params = []
                 for param in params:
                     if param is None:
-                        query = query.replace('%s', 'null', 1)
+                        query = query.replace("%s", "null", 1)
                     else:
                         new_params.append(param)
-                        query = query.replace('%s', '?', 1)
+                        query = query.replace("%s", "?", 1)
                 params = new_params
             return query, params
 
-        query = 'SELECT * FROM users'
+        query = "SELECT * FROM users"
         result_query, result_params = process_query(query, [])
 
-        assert result_query == 'SELECT * FROM users'
+        assert result_query == "SELECT * FROM users"
         assert result_params == []
 
     def test_special_characters_in_params(self):
         """Test handling of special characters in parameters."""
+
         def process_query(query, params=None):
             if params is None:
-                query = query.replace('%s', '?')
+                query = query.replace("%s", "?")
             else:
                 new_params = []
                 for param in params:
                     if param is None:
-                        query = query.replace('%s', 'null', 1)
+                        query = query.replace("%s", "null", 1)
                     else:
                         new_params.append(param)
-                        query = query.replace('%s', '?', 1)
+                        query = query.replace("%s", "?", 1)
                 params = new_params
             return query, params
 
-        query = 'INSERT INTO users (name) VALUES (%s)'
+        query = "INSERT INTO users (name) VALUES (%s)"
         params = ["test'; DROP TABLE users; --"]
         result_query, result_params = process_query(query, params)
 
         # The dangerous string should be kept as a parameter, not interpolated
         assert result_params == ["test'; DROP TABLE users; --"]
-        assert '?' in result_query
+        assert "?" in result_query
 
     def test_unicode_params(self):
         """Test handling of unicode parameters."""
+
         def process_query(query, params=None):
             if params is None:
-                query = query.replace('%s', '?')
+                query = query.replace("%s", "?")
             else:
                 new_params = []
                 for param in params:
                     if param is None:
-                        query = query.replace('%s', 'null', 1)
+                        query = query.replace("%s", "null", 1)
                     else:
                         new_params.append(param)
-                        query = query.replace('%s', '?', 1)
+                        query = query.replace("%s", "?", 1)
                 params = new_params
             return query, params
 
-        query = 'INSERT INTO users (name) VALUES (%s)'
-        params = ['']
+        query = "INSERT INTO users (name) VALUES (%s)"
+        params = [""]
         result_query, result_params = process_query(query, params)
 
-        assert result_params == ['']
+        assert result_params == [""]
 
     def test_large_number_of_params(self):
         """Test handling of many parameters."""
+
         def process_query(query, params=None):
             if params is None:
-                query = query.replace('%s', '?')
+                query = query.replace("%s", "?")
             else:
                 new_params = []
                 for param in params:
                     if param is None:
-                        query = query.replace('%s', 'null', 1)
+                        query = query.replace("%s", "null", 1)
                     else:
                         new_params.append(param)
-                        query = query.replace('%s', '?', 1)
+                        query = query.replace("%s", "?", 1)
                 params = new_params
             return query, params
 
-        placeholders = ', '.join(['%s'] * 50)
-        query = f'INSERT INTO test VALUES ({placeholders})'
+        placeholders = ", ".join(["%s"] * 50)
+        query = f"INSERT INTO test VALUES ({placeholders})"
         params = list(range(50))
         result_query, result_params = process_query(query, params)
 
-        assert result_query.count('?') == 50
+        assert result_query.count("?") == 50
         assert len(result_params) == 50

--- a/packages/django-cf/tests/db/test_do_backend.py
+++ b/packages/django-cf/tests/db/test_do_backend.py
@@ -1,7 +1,6 @@
 """Tests for django_cf/db/backends/do/base.py - Durable Objects database backend."""
-import pytest
-from unittest.mock import MagicMock, patch
-import sys
+
+from unittest.mock import MagicMock
 
 
 class TestDODatabaseWrapperProcessQuery:
@@ -20,25 +19,25 @@ class TestDODatabaseWrapperProcessQuery:
 
             def process_query(self, query, params=None):
                 if params is None:
-                    query = query.replace('%s', '?')
+                    query = query.replace("%s", "?")
                 else:
                     new_params = []
                     for param in params:
                         if param is None:
-                            query = query.replace('%s', 'null', 1)
+                            query = query.replace("%s", "null", 1)
                         else:
                             new_params.append(param)
-                            query = query.replace('%s', '?', 1)
+                            query = query.replace("%s", "?", 1)
                     params = new_params
 
                 if self.cursor()._defer_foreign_keys:
-                    return f'''
+                    return f"""
                     PRAGMA defer_foreign_keys = on
 
                     {query}
 
                     PRAGMA defer_foreign_keys = off
-                    '''
+                    """
 
                 return query, params
 
@@ -48,45 +47,45 @@ class TestDODatabaseWrapperProcessQuery:
         """Test process_query replaces %s with ? when no params."""
         wrapper = self._create_mock_wrapper()
 
-        query = 'SELECT * FROM users WHERE id = %s'
+        query = "SELECT * FROM users WHERE id = %s"
         result_query, result_params = wrapper.process_query(query, None)
 
-        assert result_query == 'SELECT * FROM users WHERE id = ?'
+        assert result_query == "SELECT * FROM users WHERE id = ?"
         assert result_params is None
 
     def test_process_query_with_params(self):
         """Test process_query replaces %s with ? for each param."""
         wrapper = self._create_mock_wrapper()
 
-        query = 'SELECT * FROM users WHERE id = %s AND name = %s'
-        params = [1, 'test']
+        query = "SELECT * FROM users WHERE id = %s AND name = %s"
+        params = [1, "test"]
         result_query, result_params = wrapper.process_query(query, params)
 
-        assert result_query == 'SELECT * FROM users WHERE id = ? AND name = ?'
-        assert result_params == [1, 'test']
+        assert result_query == "SELECT * FROM users WHERE id = ? AND name = ?"
+        assert result_params == [1, "test"]
 
     def test_process_query_null_param_replaced_with_literal(self):
         """Test process_query replaces None params with literal 'null'."""
         wrapper = self._create_mock_wrapper()
 
-        query = 'INSERT INTO users (name, email) VALUES (%s, %s)'
-        params = ['test', None]
+        query = "INSERT INTO users (name, email) VALUES (%s, %s)"
+        params = ["test", None]
         result_query, result_params = wrapper.process_query(query, params)
 
-        assert 'null' in result_query
-        assert result_params == ['test']
+        assert "null" in result_query
+        assert result_params == ["test"]
 
     def test_process_query_with_defer_foreign_keys(self):
         """Test process_query adds PRAGMA when _defer_foreign_keys is True."""
         wrapper = self._create_mock_wrapper()
         wrapper._cursor_mock._defer_foreign_keys = True
 
-        query = 'INSERT INTO users (name) VALUES (%s)'
-        params = ['test']
+        query = "INSERT INTO users (name) VALUES (%s)"
+        params = ["test"]
         result = wrapper.process_query(query, params)
 
-        assert 'PRAGMA defer_foreign_keys = on' in result
-        assert 'PRAGMA defer_foreign_keys = off' in result
+        assert "PRAGMA defer_foreign_keys = on" in result
+        assert "PRAGMA defer_foreign_keys = off" in result
 
 
 class TestDODatabaseWrapperConfiguration:
@@ -95,7 +94,8 @@ class TestDODatabaseWrapperConfiguration:
     def test_vendor_name(self):
         """Test vendor name is correct."""
         import importlib.util
-        spec = importlib.util.find_spec('django_cf.db.backends.do.base')
+
+        spec = importlib.util.find_spec("django_cf.db.backends.do.base")
         with open(spec.origin) as f:
             content = f.read()
             assert 'vendor = "cloudflare_durable_objects"' in content
@@ -103,6 +103,7 @@ class TestDODatabaseWrapperConfiguration:
 
     def test_get_connection_params_returns_empty(self):
         """Test that get_connection_params returns empty dict for DO."""
+
         # DO backend doesn't need connection params like D1 does
         class MockDOWrapper:
             def get_connection_params(self):
@@ -124,52 +125,54 @@ class TestDOMissingDateTruncBug:
         The D1 backend calls replace_date_trunc_in_sql() in process_query(),
         but the DO backend does NOT. This is a bug that should be fixed.
         """
+
         # DO backend's process_query (simulated - without date_trunc)
         def do_process_query(query, params=None):
             # Note: NO replace_date_trunc_in_sql call
             if params is None:
-                query = query.replace('%s', '?')
+                query = query.replace("%s", "?")
             else:
                 new_params = []
                 for param in params:
                     if param is None:
-                        query = query.replace('%s', 'null', 1)
+                        query = query.replace("%s", "null", 1)
                     else:
                         new_params.append(param)
-                        query = query.replace('%s', '?', 1)
+                        query = query.replace("%s", "?", 1)
                 params = new_params
             return query, params
 
         # D1 backend's process_query (simulated - with date_trunc)
         def d1_process_query(query, params=None):
             from django_cf.db.base_engine import replace_date_trunc_in_sql
+
             query = replace_date_trunc_in_sql(query)
 
             if params is None:
-                query = query.replace('%s', '?')
+                query = query.replace("%s", "?")
             else:
                 new_params = []
                 for param in params:
                     if param is None:
-                        query = query.replace('%s', 'null', 1)
+                        query = query.replace("%s", "null", 1)
                     else:
                         new_params.append(param)
-                        query = query.replace('%s', '?', 1)
+                        query = query.replace("%s", "?", 1)
                 params = new_params
             return query, params
 
-        test_query = 'SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders'
-        test_params = ['year', 'UTC', 'UTC']
+        test_query = "SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders"
+        test_params = ["year", "UTC", "UTC"]
 
         # D1 correctly replaces date_trunc
         d1_result, _ = d1_process_query(test_query, test_params)
-        assert 'django_date_trunc' not in d1_result
+        assert "django_date_trunc" not in d1_result
 
         # DO does NOT replace date_trunc (BUG)
         do_result, _ = do_process_query(test_query, test_params)
         # This shows the bug - django_date_trunc is still in the query
         # When this test fails after fix, remove the bug documentation
-        assert 'django_date_trunc' in do_result  # Bug: should NOT be in result
+        assert "django_date_trunc" in do_result  # Bug: should NOT be in result
 
 
 class TestDOStorageInitialization:
@@ -178,16 +181,18 @@ class TestDOStorageInitialization:
     def test_storage_module_exists(self):
         """Test that storage module exists for DO backend."""
         import importlib.util
-        spec = importlib.util.find_spec('django_cf.db.backends.do.storage')
+
+        spec = importlib.util.find_spec("django_cf.db.backends.do.storage")
         assert spec is not None
 
     def test_get_storage_function_exists(self):
         """Test that get_storage function exists in storage module."""
         import importlib.util
-        spec = importlib.util.find_spec('django_cf.db.backends.do.base')
+
+        spec = importlib.util.find_spec("django_cf.db.backends.do.base")
         with open(spec.origin) as f:
             content = f.read()
-            assert 'from .storage import get_storage' in content
+            assert "from .storage import get_storage" in content
 
 
 class TestDOQueryExecution:
@@ -195,6 +200,7 @@ class TestDOQueryExecution:
 
     def test_read_query_uses_raw(self):
         """Test that read queries use raw() method."""
+
         # Simulated DO run_query logic
         def mock_run_query(query, params=None, is_read=True):
             mock_db = MagicMock()
@@ -212,7 +218,7 @@ class TestDOQueryExecution:
             else:
                 return mock_stmt
 
-        result = mock_run_query('SELECT * FROM users', is_read=True)
+        result = mock_run_query("SELECT * FROM users", is_read=True)
         assert result == []
 
     def test_error_handling_exposes_stack(self):
@@ -229,12 +235,13 @@ class TestDOQueryExecution:
         #     raise Error(Error.new().stack)
 
         import importlib.util
-        spec = importlib.util.find_spec('django_cf.db.backends.do.base')
+
+        spec = importlib.util.find_spec("django_cf.db.backends.do.base")
         with open(spec.origin) as f:
             content = f.read()
             # Verify the problematic pattern exists
-            assert 'Error.stackTraceLimit = 1e10' in content
-            assert 'raise Error(Error.new().stack)' in content
+            assert "Error.stackTraceLimit = 1e10" in content
+            assert "raise Error(Error.new().stack)" in content
 
 
 class TestDOExceptionHandling:
@@ -247,18 +254,18 @@ class TestDOExceptionHandling:
         and SystemExit, which should be allowed to propagate normally.
         """
         import importlib.util
-        spec = importlib.util.find_spec('django_cf.db.backends.do.base')
+
+        spec = importlib.util.find_spec("django_cf.db.backends.do.base")
         with open(spec.origin) as f:
             content = f.read()
             # Should use 'except Exception:' not bare 'except:'
-            assert 'except Exception:' in content
+            assert "except Exception:" in content
             # Should NOT have bare except
-            lines = content.split('\n')
+            lines = content.split("\n")
             for line in lines:
                 stripped = line.strip()
-                if stripped.startswith('except') and stripped.endswith(':'):
-                    assert stripped != 'except:', \
-                        f"Found bare 'except:' clause: {line}"
+                if stripped.startswith("except") and stripped.endswith(":"):
+                    assert stripped != "except:", f"Found bare 'except:' clause: {line}"
 
 
 class TestDOParamConversion:
@@ -270,21 +277,22 @@ class TestDOParamConversion:
 
         Note: Boolean conversion happens in CFDatabase.execute(), not process_query().
         """
+
         def process_query(query, params=None):
             if params is None:
-                query = query.replace('%s', '?')
+                query = query.replace("%s", "?")
             else:
                 new_params = []
                 for param in params:
                     if param is None:
-                        query = query.replace('%s', 'null', 1)
+                        query = query.replace("%s", "null", 1)
                     else:
                         new_params.append(param)
-                        query = query.replace('%s', '?', 1)
+                        query = query.replace("%s", "?", 1)
                 params = new_params
             return query, params
 
-        query = 'INSERT INTO test (active) VALUES (%s)'
+        query = "INSERT INTO test (active) VALUES (%s)"
         params = [True]
         result_query, result_params = process_query(query, params)
 
@@ -293,28 +301,29 @@ class TestDOParamConversion:
 
     def test_multiple_none_params_order_preserved(self):
         """Test that order is preserved with multiple None params."""
+
         def process_query(query, params=None):
             if params is None:
-                query = query.replace('%s', '?')
+                query = query.replace("%s", "?")
             else:
                 new_params = []
                 for param in params:
                     if param is None:
-                        query = query.replace('%s', 'null', 1)
+                        query = query.replace("%s", "null", 1)
                     else:
                         new_params.append(param)
-                        query = query.replace('%s', '?', 1)
+                        query = query.replace("%s", "?", 1)
                 params = new_params
             return query, params
 
-        query = 'INSERT INTO test (a, b, c, d) VALUES (%s, %s, %s, %s)'
+        query = "INSERT INTO test (a, b, c, d) VALUES (%s, %s, %s, %s)"
         params = [1, None, 2, None]
         result_query, result_params = process_query(query, params)
 
         # Non-None params should be in order
         assert result_params == [1, 2]
         # Query should have correct mix of ? and null
-        assert result_query == 'INSERT INTO test (a, b, c, d) VALUES (?, null, ?, null)'
+        assert result_query == "INSERT INTO test (a, b, c, d) VALUES (?, null, ?, null)"
 
 
 class TestDOPragmaReturnTypeBug:
@@ -338,32 +347,32 @@ class TestDOPragmaReturnTypeBug:
 
             def process_query(self, query, params=None):
                 if params is None:
-                    query = query.replace('%s', '?')
+                    query = query.replace("%s", "?")
                 else:
                     new_params = []
                     for param in params:
                         if param is None:
-                            query = query.replace('%s', 'null', 1)
+                            query = query.replace("%s", "null", 1)
                         else:
                             new_params.append(param)
-                            query = query.replace('%s', '?', 1)
+                            query = query.replace("%s", "?", 1)
                     params = new_params
 
                 if self.cursor()._defer_foreign_keys:
                     # BUG: Returns string, not tuple - params are lost!
-                    return f'''
+                    return f"""
                     PRAGMA defer_foreign_keys = on
 
                     {query}
 
                     PRAGMA defer_foreign_keys = off
-                    '''
+                    """
 
                 return query, params
 
         wrapper = MockDOWrapper()
-        query = 'INSERT INTO users (name) VALUES (%s)'
-        params = ['test']
+        query = "INSERT INTO users (name) VALUES (%s)"
+        params = ["test"]
 
         result = wrapper.process_query(query, params)
 

--- a/packages/django-cf/tests/durable_objects/test_admin.py
+++ b/packages/django-cf/tests/durable_objects/test_admin.py
@@ -1,6 +1,7 @@
 import requests
 
-from ..utils import durable_objects_web_server  # NOQA
+from ..utils import durable_objects_web_server  # noqa: F401
+
 
 def get_csrf_token(client, url):
     """Fetches a page and extracts the CSRF token from a form."""
@@ -42,6 +43,7 @@ def test_admin_login_page_loads(durable_objects_web_server):
     assert response.status_code == 200
     assert "Django administration" in response.text
 
+
 def test_admin_dashboard_unauthorized_access(durable_objects_web_server):
     """Test that accessing the admin dashboard without login redirects to the login page."""
     admin_dashboard_url = f"{durable_objects_web_server.base_url}/admin/"
@@ -49,7 +51,9 @@ def test_admin_dashboard_unauthorized_access(durable_objects_web_server):
 
     client = requests.Session()
     # First check with allow_redirects=False to see the 302
-    response_no_redirect = client.get(admin_dashboard_url, timeout=10, allow_redirects=False)
+    response_no_redirect = client.get(
+        admin_dashboard_url, timeout=10, allow_redirects=False
+    )
     assert response_no_redirect.status_code == 302
     location_header = response_no_redirect.headers.get("Location", "")
     # The location might be relative /admin/login/?next=/admin/ or absolute
@@ -59,8 +63,13 @@ def test_admin_dashboard_unauthorized_access(durable_objects_web_server):
     # Then check with allow_redirects=True (default) to ensure it lands on the login page
     response_followed = client.get(admin_dashboard_url, timeout=10)
     assert response_followed.status_code == 200
-    assert response_followed.url.startswith(login_url) # Final URL should be the login page
-    assert "Django administration" in response_followed.text # Should show the login page content
+    assert response_followed.url.startswith(
+        login_url
+    )  # Final URL should be the login page
+    assert (
+        "Django administration" in response_followed.text
+    )  # Should show the login page content
+
 
 def test_admin_login_successful(durable_objects_web_server):
     """Test a successful login to the Django admin."""
@@ -79,7 +88,7 @@ def test_admin_login_successful(durable_objects_web_server):
     response = client.post(login_url, data=login_data, headers=headers, timeout=10)
 
     assert response.status_code == 200
-    assert response.url.rstrip('/') == admin_dashboard_url.rstrip('/')
+    assert response.url.rstrip("/") == admin_dashboard_url.rstrip("/")
     assert "Site administration" in response.text
     assert "Log out" in response.text
 
@@ -102,6 +111,7 @@ def test_admin_login_failed_wrong_password(durable_objects_web_server):
     assert "Please enter the correct username and password" in response.text
     assert "Log out" not in response.text
 
+
 def test_admin_login_failed_wrong_username(durable_objects_web_server):
     """Test a failed login attempt with a non-existent username."""
     login_url = f"{durable_objects_web_server.base_url}/admin/login/"
@@ -120,6 +130,7 @@ def test_admin_login_failed_wrong_username(durable_objects_web_server):
     assert "Please enter the correct username and password" in response.text
     assert "Log out" not in response.text
 
+
 def test_admin_logout(durable_objects_web_server):
     """Test logging out from the Django admin."""
     login_url = f"{durable_objects_web_server.base_url}/admin/login/"
@@ -136,9 +147,11 @@ def test_admin_logout(durable_objects_web_server):
         "next": "/admin/",
     }
     headers_login = {"Referer": login_url}
-    response_login = client.post(login_url, data=login_data, headers=headers_login, timeout=10)
+    response_login = client.post(
+        login_url, data=login_data, headers=headers_login, timeout=10
+    )
     assert response_login.status_code == 200
-    assert response_login.url.rstrip('/') == admin_dashboard_url.rstrip('/')
+    assert response_login.url.rstrip("/") == admin_dashboard_url.rstrip("/")
     assert "Log out" in response_login.text
 
     # 2. Logout
@@ -160,22 +173,34 @@ def test_admin_logout(durable_objects_web_server):
 
     csrf_token_logout = get_csrf_token(client, admin_dashboard_url)
 
-    headers_logout = {"Referer": admin_dashboard_url} # Referer should be the page from which the POST is made
-    response_logout = client.post(logout_url, data={"csrfmiddlewaretoken": csrf_token_logout}, headers=headers_logout, timeout=10)
+    headers_logout = {
+        "Referer": admin_dashboard_url
+    }  # Referer should be the page from which the POST is made
+    response_logout = client.post(
+        logout_url,
+        data={"csrfmiddlewaretoken": csrf_token_logout},
+        headers=headers_logout,
+        timeout=10,
+    )
 
     # After a successful POST to /admin/logout/, Django typically redirects to the login page.
     # The status code of the POST response itself might be 200 (if it renders a "Logged out" page)
     # or 302 (if it immediately redirects). We should check the content of the page it lands on.
     # If it's 302, the client will follow it if allow_redirects is True (default for client.post).
 
-    assert response_logout.status_code == 200 # Django's default logout view returns 200
+    assert (
+        response_logout.status_code == 200
+    )  # Django's default logout view returns 200
     # Check for text that appears on the "Logged out" confirmation page, which is often the login page with a message.
     # For Django < 4.0, it's "Logged out". For Django 4.0+, it's "Logged out". Django 5.0 shows "Log in again" on the login page.
-    assert "Logged out" in response_logout.text or "Log in again" in response_logout.text
-
+    assert (
+        "Logged out" in response_logout.text or "Log in again" in response_logout.text
+    )
 
     # 3. Verify user is logged out by trying to access an authenticated page
-    response_dashboard_after_logout = client.get(admin_dashboard_url, timeout=10, allow_redirects=True) # allow_redirects is True by default for GET too
+    response_dashboard_after_logout = client.get(
+        admin_dashboard_url, timeout=10, allow_redirects=True
+    )  # allow_redirects is True by default for GET too
     assert response_dashboard_after_logout.status_code == 200
     assert response_dashboard_after_logout.url.startswith(login_url)
     assert "Django administration" in response_dashboard_after_logout.text

--- a/packages/django-cf/tests/durable_objects/test_worker.py
+++ b/packages/django-cf/tests/durable_objects/test_worker.py
@@ -1,16 +1,22 @@
 import requests
 
-from ..utils import durable_objects_web_server  # NOQA
+from ..utils import durable_objects_web_server  # noqa: F401
+
 
 def test_migrations(durable_objects_web_server):
     """Run migrations."""
-    response = requests.get(f"{durable_objects_web_server.base_url}/__run_migrations__/")
+    response = requests.get(
+        f"{durable_objects_web_server.base_url}/__run_migrations__/"
+    )
     assert response.status_code == 200
     assert response.json() == {"status": "success", "message": "Migrations applied."}
+
 
 def test_create_admin(durable_objects_web_server):
     """Create an admin user a second time should return different state."""
     response = requests.get(f"{durable_objects_web_server.base_url}/__create_admin__/")
     assert response.status_code == 200
-    assert response.json() == {"status": "info", "message": f"Admin user 'admin' already exists."}
-
+    assert response.json() == {
+        "status": "info",
+        "message": "Admin user 'admin' already exists.",
+    }

--- a/packages/django-cf/tests/e2e/test_workflows.py
+++ b/packages/django-cf/tests/e2e/test_workflows.py
@@ -3,12 +3,16 @@
 These tests verify complete user workflows through the HTTP endpoints.
 They require running Cloudflare Workers via wrangler.
 """
+
 import pytest
 import requests
 
-
 # Import fixtures from utils
-from ..utils import d1_web_server, durable_objects_web_server, r2_web_server  # NOQA
+from ..utils import (  # noqa: F401
+    d1_web_server,
+    durable_objects_web_server,
+    r2_web_server,
+)
 
 
 class TestD1CRUDWorkflow:
@@ -24,7 +28,7 @@ class TestD1CRUDWorkflow:
         assert response.status_code == 200
         result = response.json()
         # Either created or already exists
-        assert result['status'] in ['success', 'info']
+        assert result["status"] in ["success", "info"]
 
     def test_migrations_are_applied(self, d1_web_server):
         """Test that migrations are properly applied."""
@@ -34,7 +38,7 @@ class TestD1CRUDWorkflow:
         response = requests.get(f"{base_url}/__run_migrations__/")
         assert response.status_code == 200
         result = response.json()
-        assert result['status'] == 'success'
+        assert result["status"] == "success"
 
     def test_admin_user_persistence(self, d1_web_server):
         """Test that admin user persists across requests."""
@@ -48,8 +52,8 @@ class TestD1CRUDWorkflow:
         response2 = requests.get(f"{base_url}/__create_admin__/")
         assert response2.status_code == 200
         result = response2.json()
-        assert result['status'] == 'info'
-        assert 'already exists' in result['message']
+        assert result["status"] == "info"
+        assert "already exists" in result["message"]
 
 
 class TestDurableObjectsCRUDWorkflow:
@@ -63,7 +67,7 @@ class TestDurableObjectsCRUDWorkflow:
         response = requests.get(f"{base_url}/__create_admin__/")
         assert response.status_code == 200
         result = response.json()
-        assert result['status'] in ['success', 'info']
+        assert result["status"] in ["success", "info"]
 
     def test_migrations_are_applied(self, durable_objects_web_server):
         """Test that migrations are properly applied on DO."""
@@ -72,7 +76,7 @@ class TestDurableObjectsCRUDWorkflow:
         response = requests.get(f"{base_url}/__run_migrations__/")
         assert response.status_code == 200
         result = response.json()
-        assert result['status'] == 'success'
+        assert result["status"] == "success"
 
     def test_admin_user_persistence(self, durable_objects_web_server):
         """Test that admin user persists across requests on DO."""
@@ -86,8 +90,8 @@ class TestDurableObjectsCRUDWorkflow:
         response2 = requests.get(f"{base_url}/__create_admin__/")
         assert response2.status_code == 200
         result = response2.json()
-        assert result['status'] == 'info'
-        assert 'already exists' in result['message']
+        assert result["status"] == "info"
+        assert "already exists" in result["message"]
 
 
 class TestR2StorageWorkflow:
@@ -96,43 +100,43 @@ class TestR2StorageWorkflow:
     def test_upload_download_delete_workflow(self, r2_web_server):
         """Test complete file upload, download, delete workflow."""
         base_url = r2_web_server.base_url
-        test_path = 'workflow_test/test_file.txt'
-        test_content = b'Workflow test content'
+        test_path = "workflow_test/test_file.txt"
+        test_content = b"Workflow test content"
 
         # 1. Upload file
         upload_url = f"{base_url}/__r2_upload__/"
-        files = {'file': ('test_file.txt', test_content, 'text/plain')}
-        data = {'path': test_path}
+        files = {"file": ("test_file.txt", test_content, "text/plain")}
+        data = {"path": test_path}
         response = requests.post(upload_url, files=files, data=data, timeout=10)
         assert response.status_code == 200
 
         # 2. Verify file exists
         exists_url = f"{base_url}/__r2_exists__/"
-        response = requests.get(exists_url, params={'path': test_path}, timeout=10)
+        response = requests.get(exists_url, params={"path": test_path}, timeout=10)
         assert response.status_code == 200
-        assert response.json()['exists'] is True
+        assert response.json()["exists"] is True
 
         # 3. Download and verify content
         download_url = f"{base_url}/__r2_download__/"
-        response = requests.get(download_url, params={'path': test_path}, timeout=10)
+        response = requests.get(download_url, params={"path": test_path}, timeout=10)
         assert response.status_code == 200
         assert response.content == test_content
 
         # 4. Check file size
         size_url = f"{base_url}/__r2_size__/"
-        response = requests.get(size_url, params={'path': test_path}, timeout=10)
+        response = requests.get(size_url, params={"path": test_path}, timeout=10)
         assert response.status_code == 200
-        assert response.json()['size'] == len(test_content)
+        assert response.json()["size"] == len(test_content)
 
         # 5. Delete file
         delete_url = f"{base_url}/__r2_delete__/"
-        response = requests.post(delete_url, data={'path': test_path}, timeout=10)
+        response = requests.post(delete_url, data={"path": test_path}, timeout=10)
         assert response.status_code == 200
 
         # 6. Verify file no longer exists
-        response = requests.get(exists_url, params={'path': test_path}, timeout=10)
+        response = requests.get(exists_url, params={"path": test_path}, timeout=10)
         assert response.status_code == 200
-        assert response.json()['exists'] is False
+        assert response.json()["exists"] is False
 
     def test_directory_operations_workflow(self, r2_web_server):
         """Test directory listing workflow."""
@@ -141,32 +145,32 @@ class TestR2StorageWorkflow:
 
         # Create directory structure
         test_files = [
-            ('dir_test/file1.txt', b'Content 1'),
-            ('dir_test/file2.txt', b'Content 2'),
-            ('dir_test/subdir/file3.txt', b'Content 3'),
+            ("dir_test/file1.txt", b"Content 1"),
+            ("dir_test/file2.txt", b"Content 2"),
+            ("dir_test/subdir/file3.txt", b"Content 3"),
         ]
 
         for path, content in test_files:
-            files = {'file': (path.split('/')[-1], content, 'text/plain')}
-            data = {'path': path}
+            files = {"file": (path.split("/")[-1], content, "text/plain")}
+            data = {"path": path}
             response = requests.post(upload_url, files=files, data=data, timeout=10)
             assert response.status_code == 200
 
         # List directory
         listdir_url = f"{base_url}/__r2_listdir__/"
-        response = requests.get(listdir_url, params={'path': 'dir_test'}, timeout=10)
+        response = requests.get(listdir_url, params={"path": "dir_test"}, timeout=10)
         assert response.status_code == 200
 
         result = response.json()
-        assert 'directories' in result
-        assert 'files' in result
-        assert 'subdir' in result['directories']
-        assert 'file1.txt' in result['files']
-        assert 'file2.txt' in result['files']
+        assert "directories" in result
+        assert "files" in result
+        assert "subdir" in result["directories"]
+        assert "file1.txt" in result["files"]
+        assert "file2.txt" in result["files"]
 
     @pytest.mark.xfail(
         reason="Framework limitation: django_cf/__init__.py:58 calls resp.content.decode('utf-8') "
-               "which fails for binary content. See handle_wsgi function."
+        "which fails for binary content. See handle_wsgi function."
     )
     def test_binary_file_workflow(self, r2_web_server):
         """Test binary file upload and download.
@@ -175,21 +179,21 @@ class TestR2StorageWorkflow:
         responses fail because handle_wsgi() tries to decode content as UTF-8.
         """
         base_url = r2_web_server.base_url
-        test_path = 'binary_test/image.bin'
+        test_path = "binary_test/image.bin"
 
         # Create binary content with bytes that can't be decoded as UTF-8
         binary_content = bytes(range(256))
 
         # Upload
         upload_url = f"{base_url}/__r2_upload__/"
-        files = {'file': ('image.bin', binary_content, 'application/octet-stream')}
-        data = {'path': test_path}
+        files = {"file": ("image.bin", binary_content, "application/octet-stream")}
+        data = {"path": test_path}
         response = requests.post(upload_url, files=files, data=data, timeout=10)
         assert response.status_code == 200
 
         # Download and verify - this fails due to UTF-8 decode in handle_wsgi
         download_url = f"{base_url}/__r2_download__/"
-        response = requests.get(download_url, params={'path': test_path}, timeout=10)
+        response = requests.get(download_url, params={"path": test_path}, timeout=10)
         assert response.status_code == 200
         assert response.content == binary_content
 
@@ -213,22 +217,18 @@ class TestErrorRecoveryWorkflow:
         # Try to download non-existent file
         download_url = f"{base_url}/__r2_download__/"
         response = requests.get(
-            download_url,
-            params={'path': 'definitely/not/a/real/file.txt'},
-            timeout=10
+            download_url, params={"path": "definitely/not/a/real/file.txt"}, timeout=10
         )
         # Should return error status, not crash
-        assert response.status_code >= 400 or response.content == b''
+        assert response.status_code >= 400 or response.content == b""
 
         # Exists check should return False, not error
         exists_url = f"{base_url}/__r2_exists__/"
         response = requests.get(
-            exists_url,
-            params={'path': 'definitely/not/a/real/file.txt'},
-            timeout=10
+            exists_url, params={"path": "definitely/not/a/real/file.txt"}, timeout=10
         )
         assert response.status_code == 200
-        assert response.json()['exists'] is False
+        assert response.json()["exists"] is False
 
 
 class TestConcurrentRequestsWorkflow:
@@ -260,8 +260,14 @@ class TestConcurrentRequestsWorkflow:
         upload_url = f"{base_url}/__r2_upload__/"
 
         def upload_file(index):
-            files = {'file': (f'concurrent_{index}.txt', f'Content {index}'.encode(), 'text/plain')}
-            data = {'path': f'concurrent_test/file_{index}.txt'}
+            files = {
+                "file": (
+                    f"concurrent_{index}.txt",
+                    f"Content {index}".encode(),
+                    "text/plain",
+                )
+            }
+            data = {"path": f"concurrent_test/file_{index}.txt"}
             response = requests.post(upload_url, files=files, data=data, timeout=10)
             return response.status_code
 
@@ -280,27 +286,27 @@ class TestLargeDataWorkflow:
     def test_r2_handles_larger_file(self, r2_web_server):
         """Test R2 handles larger files (1MB)."""
         base_url = r2_web_server.base_url
-        test_path = 'large_test/large_file.bin'
+        test_path = "large_test/large_file.bin"
 
         # Create 1MB of data
-        large_content = b'x' * (1024 * 1024)
+        large_content = b"x" * (1024 * 1024)
 
         # Upload
         upload_url = f"{base_url}/__r2_upload__/"
-        files = {'file': ('large_file.bin', large_content, 'application/octet-stream')}
-        data = {'path': test_path}
+        files = {"file": ("large_file.bin", large_content, "application/octet-stream")}
+        data = {"path": test_path}
         response = requests.post(upload_url, files=files, data=data, timeout=30)
         assert response.status_code == 200
 
         # Verify size
         size_url = f"{base_url}/__r2_size__/"
-        response = requests.get(size_url, params={'path': test_path}, timeout=10)
+        response = requests.get(size_url, params={"path": test_path}, timeout=10)
         assert response.status_code == 200
-        assert response.json()['size'] == len(large_content)
+        assert response.json()["size"] == len(large_content)
 
         # Download and verify
         download_url = f"{base_url}/__r2_download__/"
-        response = requests.get(download_url, params={'path': test_path}, timeout=30)
+        response = requests.get(download_url, params={"path": test_path}, timeout=30)
         assert response.status_code == 200
         assert len(response.content) == len(large_content)
 
@@ -312,35 +318,35 @@ class TestSpecialCharactersWorkflow:
         """Test R2 handles unicode characters in filenames."""
         base_url = r2_web_server.base_url
         # Use ASCII-safe path for URL but unicode in content
-        test_path = 'unicode_test/file_unicode.txt'
-        unicode_content = 'Hello'.encode('utf-8')
+        test_path = "unicode_test/file_unicode.txt"
+        unicode_content = b"Hello"
 
         upload_url = f"{base_url}/__r2_upload__/"
-        files = {'file': ('file.txt', unicode_content, 'text/plain; charset=utf-8')}
-        data = {'path': test_path}
+        files = {"file": ("file.txt", unicode_content, "text/plain; charset=utf-8")}
+        data = {"path": test_path}
         response = requests.post(upload_url, files=files, data=data, timeout=10)
         assert response.status_code == 200
 
         # Download and verify
         download_url = f"{base_url}/__r2_download__/"
-        response = requests.get(download_url, params={'path': test_path}, timeout=10)
+        response = requests.get(download_url, params={"path": test_path}, timeout=10)
         assert response.status_code == 200
         assert response.content == unicode_content
 
     def test_r2_handles_spaces_in_path(self, r2_web_server):
         """Test R2 handles spaces in file paths."""
         base_url = r2_web_server.base_url
-        test_path = 'space test/file with spaces.txt'
-        test_content = b'Content with spaces in path'
+        test_path = "space test/file with spaces.txt"
+        test_content = b"Content with spaces in path"
 
         upload_url = f"{base_url}/__r2_upload__/"
-        files = {'file': ('file with spaces.txt', test_content, 'text/plain')}
-        data = {'path': test_path}
+        files = {"file": ("file with spaces.txt", test_content, "text/plain")}
+        data = {"path": test_path}
         response = requests.post(upload_url, files=files, data=data, timeout=10)
         assert response.status_code == 200
 
         # Verify exists
         exists_url = f"{base_url}/__r2_exists__/"
-        response = requests.get(exists_url, params={'path': test_path}, timeout=10)
+        response = requests.get(exists_url, params={"path": test_path}, timeout=10)
         assert response.status_code == 200
-        assert response.json()['exists'] is True
+        assert response.json()["exists"] is True

--- a/packages/django-cf/tests/middleware/test_cloudflare_access.py
+++ b/packages/django-cf/tests/middleware/test_cloudflare_access.py
@@ -1,9 +1,9 @@
 """Tests for CloudflareAccessMiddleware."""
+
 import base64
-import hashlib
 import json
 import time
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -12,8 +12,8 @@ import pytest
 def base64url_encode(data):
     """Encode bytes to base64url string without padding."""
     if isinstance(data, str):
-        data = data.encode('utf-8')
-    return base64.urlsafe_b64encode(data).rstrip(b'=').decode('utf-8')
+        data = data.encode("utf-8")
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("utf-8")
 
 
 def create_jwt_parts(header, payload):
@@ -23,12 +23,12 @@ def create_jwt_parts(header, payload):
     return header_b64, payload_b64
 
 
-def create_test_jwt(payload, kid='test-key-1'):
+def create_test_jwt(payload, kid="test-key-1"):
     """Create a test JWT (unsigned, for testing extraction functions)."""
-    header = {'alg': 'RS256', 'typ': 'JWT', 'kid': kid}
+    header = {"alg": "RS256", "typ": "JWT", "kid": kid}
     header_b64, payload_b64 = create_jwt_parts(header, payload)
     # Fake signature for structure testing
-    signature_b64 = base64url_encode(b'fake-signature')
+    signature_b64 = base64url_encode(b"fake-signature")
     return f"{header_b64}.{payload_b64}.{signature_b64}"
 
 
@@ -36,9 +36,9 @@ def create_test_jwt(payload, kid='test-key-1'):
 def mock_django_settings():
     """Mock Django settings for middleware."""
     settings = MagicMock()
-    settings.CLOUDFLARE_ACCESS_AUD = 'test-aud-12345'
-    settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
-    settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = ['/health/', '/public/']
+    settings.CLOUDFLARE_ACCESS_AUD = "test-aud-12345"
+    settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
+    settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = ["/health/", "/public/"]
     settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
     return settings
 
@@ -47,10 +47,10 @@ def mock_django_settings():
 def mock_user_model():
     """Mock Django User model."""
     user = MagicMock()
-    user.email = 'test@example.com'
-    user.first_name = 'Test'
-    user.last_name = 'User'
-    user.get_full_name.return_value = 'Test User'
+    user.email = "test@example.com"
+    user.first_name = "Test"
+    user.last_name = "User"
+    user.get_full_name.return_value = "Test User"
     return user
 
 
@@ -60,7 +60,7 @@ def mock_request():
     request = MagicMock()
     request.META = {}
     request.COOKIES = {}
-    request.path = '/api/resource/'
+    request.path = "/api/resource/"
     request.session = MagicMock()
     return request
 
@@ -70,87 +70,115 @@ class TestJWTExtraction:
 
     def test_extract_jwt_from_header(self, mock_request):
         """Test extracting JWT from CF-Access-Jwt-Assertion header."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
-                test_token = 'header-jwt-token'
-                mock_request.META['HTTP_CF_ACCESS_JWT_ASSERTION'] = test_token
+                test_token = "header-jwt-token"
+                mock_request.META["HTTP_CF_ACCESS_JWT_ASSERTION"] = test_token
 
                 result = middleware._extract_jwt_token(mock_request)
                 assert result == test_token
 
     def test_extract_jwt_from_cookie(self, mock_request):
         """Test extracting JWT from CF_Authorization cookie."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
-                test_token = 'cookie-jwt-token'
-                mock_request.COOKIES['CF_Authorization'] = test_token
+                test_token = "cookie-jwt-token"
+                mock_request.COOKIES["CF_Authorization"] = test_token
 
                 result = middleware._extract_jwt_token(mock_request)
                 assert result == test_token
 
     def test_extract_jwt_from_lowercase_cookie(self, mock_request):
         """Test extracting JWT from cf_authorization cookie (lowercase)."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
-                test_token = 'lowercase-cookie-jwt-token'
-                mock_request.COOKIES['cf_authorization'] = test_token
+                test_token = "lowercase-cookie-jwt-token"
+                mock_request.COOKIES["cf_authorization"] = test_token
 
                 result = middleware._extract_jwt_token(mock_request)
                 assert result == test_token
 
     def test_extract_jwt_no_token(self, mock_request):
         """Test that None is returned when no JWT is present."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
@@ -165,23 +193,31 @@ class TestJWTExtraction:
         'HTTP-CF-ACCESS-JWT-ASSERTION' - a key that could never exist in
         Django's request.META (Django always uses underscores for HTTP headers).
         """
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
                 # Verify the source code does NOT contain the broken dash-based lookup
                 import inspect
+
                 source = inspect.getsource(middleware._extract_jwt_token)
                 assert ".replace('_', '-')" not in source
                 assert '.replace("_", "-")' not in source
@@ -193,32 +229,39 @@ class TestJWTExtraction:
                 assert result is None
 
                 # With correct underscore-based header key, should find it
-                mock_request.META = {'HTTP_CF_ACCESS_JWT_ASSERTION': 'test-token'}
+                mock_request.META = {"HTTP_CF_ACCESS_JWT_ASSERTION": "test-token"}
                 result = middleware._extract_jwt_token(mock_request)
-                assert result == 'test-token'
+                assert result == "test-token"
 
     def test_header_takes_precedence_over_cookie(self, mock_request):
         """Test that header JWT takes precedence over cookie."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
-                mock_request.META['HTTP_CF_ACCESS_JWT_ASSERTION'] = 'header-token'
-                mock_request.COOKIES['CF_Authorization'] = 'cookie-token'
+                mock_request.META["HTTP_CF_ACCESS_JWT_ASSERTION"] = "header-token"
+                mock_request.COOKIES["CF_Authorization"] = "cookie-token"
 
                 result = middleware._extract_jwt_token(mock_request)
-                assert result == 'header-token'
+                assert result == "header-token"
 
 
 class TestTeamNameExtraction:
@@ -226,50 +269,64 @@ class TestTeamNameExtraction:
 
     def test_extract_team_name_from_valid_jwt(self):
         """Test extracting team name from JWT issuer claim."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
                 payload = {
-                    'iss': 'https://myteam.cloudflareaccess.com',
-                    'email': 'user@example.com'
+                    "iss": "https://myteam.cloudflareaccess.com",
+                    "email": "user@example.com",
                 }
                 jwt_token = create_test_jwt(payload)
 
                 result = middleware._extract_team_name_from_jwt(jwt_token)
-                assert result == 'myteam'
+                assert result == "myteam"
 
     def test_extract_team_name_invalid_issuer_format(self):
         """Test that None is returned for non-Cloudflare issuer."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
                 payload = {
-                    'iss': 'https://other-issuer.com',
-                    'email': 'user@example.com'
+                    "iss": "https://other-issuer.com",
+                    "email": "user@example.com",
                 }
                 jwt_token = create_test_jwt(payload)
 
@@ -278,22 +335,29 @@ class TestTeamNameExtraction:
 
     def test_extract_team_name_missing_issuer(self):
         """Test that None is returned when issuer is missing."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
-                payload = {'email': 'user@example.com'}
+                payload = {"email": "user@example.com"}
                 jwt_token = create_test_jwt(payload)
 
                 result = middleware._extract_team_name_from_jwt(jwt_token)
@@ -301,23 +365,30 @@ class TestTeamNameExtraction:
 
     def test_extract_team_name_malformed_jwt(self):
         """Test that None is returned for malformed JWT."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
                 # JWT with only 2 parts instead of 3
-                result = middleware._extract_team_name_from_jwt('invalid.jwt')
+                result = middleware._extract_team_name_from_jwt("invalid.jwt")
                 assert result is None
 
 
@@ -326,65 +397,86 @@ class TestExemptPaths:
 
     def test_exempt_path_matches(self):
         """Test that exempt paths are correctly identified."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
-                mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = ['/health/', '/public/']
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
+                mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = ["/health/", "/public/"]
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
-                assert middleware._is_exempt_path('/health/') is True
-                assert middleware._is_exempt_path('/health/check') is True
-                assert middleware._is_exempt_path('/public/') is True
-                assert middleware._is_exempt_path('/public/resource') is True
+                assert middleware._is_exempt_path("/health/") is True
+                assert middleware._is_exempt_path("/health/check") is True
+                assert middleware._is_exempt_path("/public/") is True
+                assert middleware._is_exempt_path("/public/resource") is True
 
     def test_non_exempt_path(self):
         """Test that non-exempt paths are correctly identified."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
-                mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = ['/health/', '/public/']
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
+                mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = ["/health/", "/public/"]
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
-                assert middleware._is_exempt_path('/api/') is False
-                assert middleware._is_exempt_path('/admin/') is False
-                assert middleware._is_exempt_path('/') is False
+                assert middleware._is_exempt_path("/api/") is False
+                assert middleware._is_exempt_path("/admin/") is False
+                assert middleware._is_exempt_path("/") is False
 
     def test_empty_exempt_paths(self):
         """Test behavior with no exempt paths configured."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
-                assert middleware._is_exempt_path('/any/path/') is False
+                assert middleware._is_exempt_path("/any/path/") is False
 
 
 class TestMiddlewareInitialization:
@@ -392,87 +484,121 @@ class TestMiddlewareInitialization:
 
     def test_init_with_aud_only(self):
         """Test initialization with only AUD setting."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
                 mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = None
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
-                assert middleware.aud == 'test-aud'
+                assert middleware.aud == "test-aud"
                 assert middleware.team_name is None
                 assert middleware.team_domain is None
                 assert middleware.certs_url is None
 
     def test_init_with_team_name_only(self):
         """Test initialization with only team name setting."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
                 mock_settings.CLOUDFLARE_ACCESS_AUD = None
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
                 assert middleware.aud is None
-                assert middleware.team_name == 'testteam'
-                assert middleware.team_domain == 'testteam.cloudflareaccess.com'
-                assert middleware.certs_url == 'https://testteam.cloudflareaccess.com/cdn-cgi/access/certs'
+                assert middleware.team_name == "testteam"
+                assert middleware.team_domain == "testteam.cloudflareaccess.com"
+                assert (
+                    middleware.certs_url
+                    == "https://testteam.cloudflareaccess.com/cdn-cgi/access/certs"
+                )
 
     def test_init_with_both_settings(self):
         """Test initialization with both AUD and team name."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
-                assert middleware.aud == 'test-aud'
-                assert middleware.team_name == 'testteam'
+                assert middleware.aud == "test-aud"
+                assert middleware.team_name == "testteam"
 
     def test_init_without_required_settings(self):
         """Test that ValueError is raised without required settings."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
                 mock_settings.CLOUDFLARE_ACCESS_AUD = None
                 mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = None
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 with pytest.raises(ValueError) as exc_info:
                     CloudflareAccessMiddleware(lambda r: r)
 
-                assert "Either CLOUDFLARE_ACCESS_AUD or CLOUDFLARE_ACCESS_TEAM_NAME" in str(exc_info.value)
+                assert (
+                    "Either CLOUDFLARE_ACCESS_AUD or CLOUDFLARE_ACCESS_TEAM_NAME"
+                    in str(exc_info.value)
+                )
 
 
 class TestBase64UrlDecode:
@@ -480,46 +606,60 @@ class TestBase64UrlDecode:
 
     def test_base64url_decode_standard(self):
         """Test standard base64url decoding."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
                 # Test with known value
-                encoded = base64url_encode(b'hello world')
+                encoded = base64url_encode(b"hello world")
                 result = middleware._base64url_decode(encoded)
-                assert result == b'hello world'
+                assert result == b"hello world"
 
     def test_base64url_decode_with_padding_needed(self):
         """Test base64url decoding with padding that needs to be added."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
                 # 'ab' encodes to 'YWI' which needs 1 padding char
-                result = middleware._base64url_decode('YWI')
-                assert result == b'ab'
+                result = middleware._base64url_decode("YWI")
+                assert result == b"ab"
 
 
 class TestJWTDecodeAndVerify:
@@ -527,137 +667,172 @@ class TestJWTDecodeAndVerify:
 
     def test_decode_jwt_invalid_format(self):
         """Test that invalid JWT format returns None."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
-                key_data = {'kid': 'test-key', 'n': 123, 'e': 65537}
+                key_data = {"kid": "test-key", "n": 123, "e": 65537}
 
                 # JWT with wrong number of parts
-                result = middleware._decode_and_verify_jwt('only.two', key_data)
+                result = middleware._decode_and_verify_jwt("only.two", key_data)
                 assert result is None
 
     def test_decode_jwt_key_id_mismatch(self):
         """Test that key ID mismatch returns None."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
                 # Create JWT with one key ID
-                payload = {'email': 'test@example.com'}
-                jwt_token = create_test_jwt(payload, kid='key-1')
+                payload = {"email": "test@example.com"}
+                jwt_token = create_test_jwt(payload, kid="key-1")
 
                 # Try to verify with different key ID
-                key_data = {'kid': 'key-2', 'n': 123, 'e': 65537}
+                key_data = {"kid": "key-2", "n": 123, "e": 65537}
 
                 result = middleware._decode_and_verify_jwt(jwt_token, key_data)
                 assert result is None
 
     def test_decode_jwt_unsupported_algorithm(self):
         """Test that unsupported algorithm returns None."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
                 # Create JWT with HS256 algorithm
-                header = {'alg': 'HS256', 'typ': 'JWT', 'kid': 'test-key'}
-                payload = {'email': 'test@example.com'}
+                header = {"alg": "HS256", "typ": "JWT", "kid": "test-key"}
+                payload = {"email": "test@example.com"}
                 header_b64, payload_b64 = create_jwt_parts(header, payload)
-                signature_b64 = base64url_encode(b'fake-signature')
+                signature_b64 = base64url_encode(b"fake-signature")
                 jwt_token = f"{header_b64}.{payload_b64}.{signature_b64}"
 
-                key_data = {'kid': 'test-key', 'n': 123, 'e': 65537}
+                key_data = {"kid": "test-key", "n": 123, "e": 65537}
 
                 result = middleware._decode_and_verify_jwt(jwt_token, key_data)
                 assert result is None
 
     def test_decode_jwt_expired_token(self):
         """Test that expired token returns None."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
                 # Create expired JWT
                 payload = {
-                    'email': 'test@example.com',
-                    'exp': int(time.time()) - 3600  # Expired 1 hour ago
+                    "email": "test@example.com",
+                    "exp": int(time.time()) - 3600,  # Expired 1 hour ago
                 }
-                jwt_token = create_test_jwt(payload, kid='test-key')
+                jwt_token = create_test_jwt(payload, kid="test-key")
 
-                key_data = {'kid': 'test-key', 'n': 123, 'e': 65537}
+                key_data = {"kid": "test-key", "n": 123, "e": 65537}
 
                 result = middleware._decode_and_verify_jwt(jwt_token, key_data)
                 assert result is None
 
     def test_decode_jwt_not_yet_valid(self):
         """Test that not-yet-valid token returns None."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
                 # Create JWT with nbf in the future
                 payload = {
-                    'email': 'test@example.com',
-                    'nbf': int(time.time()) + 3600  # Valid in 1 hour
+                    "email": "test@example.com",
+                    "nbf": int(time.time()) + 3600,  # Valid in 1 hour
                 }
-                jwt_token = create_test_jwt(payload, kid='test-key')
+                jwt_token = create_test_jwt(payload, kid="test-key")
 
-                key_data = {'kid': 'test-key', 'n': 123, 'e': 65537}
+                key_data = {"kid": "test-key", "n": 123, "e": 65537}
 
                 result = middleware._decode_and_verify_jwt(jwt_token, key_data)
                 assert result is None
@@ -668,57 +843,73 @@ class TestRSAKeyProcessing:
 
     def test_process_rsa_key_valid(self):
         """Test processing valid RSA key from JWK."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
                 # Sample JWK with small values for testing
                 key_info = {
-                    'kty': 'RSA',
-                    'kid': 'test-key-1',
-                    'n': base64url_encode(b'\x00\x01\x00\x01'),  # Small modulus for testing
-                    'e': base64url_encode(b'\x01\x00\x01')  # Exponent (65537)
+                    "kty": "RSA",
+                    "kid": "test-key-1",
+                    "n": base64url_encode(
+                        b"\x00\x01\x00\x01"
+                    ),  # Small modulus for testing
+                    "e": base64url_encode(b"\x01\x00\x01"),  # Exponent (65537)
                 }
 
                 result = middleware._process_rsa_key(key_info)
 
                 assert result is not None
-                assert result['kid'] == 'test-key-1'
-                assert 'n' in result
-                assert 'e' in result
+                assert result["kid"] == "test-key-1"
+                assert "n" in result
+                assert "e" in result
 
     def test_process_rsa_key_missing_n(self):
         """Test that missing modulus returns None."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
                 key_info = {
-                    'kty': 'RSA',
-                    'kid': 'test-key-1',
-                    'e': base64url_encode(b'\x01\x00\x01')
+                    "kty": "RSA",
+                    "kid": "test-key-1",
+                    "e": base64url_encode(b"\x01\x00\x01"),
                     # 'n' is missing
                 }
 
@@ -727,25 +918,32 @@ class TestRSAKeyProcessing:
 
     def test_process_rsa_key_missing_e(self):
         """Test that missing exponent returns None."""
-        with patch.dict('sys.modules', {'django.contrib.auth': MagicMock(),
-                                         'django.contrib.auth.models': MagicMock(),
-                                         'django.http': MagicMock(),
-                                         'django.conf': MagicMock(),
-                                         'django.core.cache': MagicMock()}):
-            with patch('django.conf.settings') as mock_settings:
-                mock_settings.CLOUDFLARE_ACCESS_AUD = 'test-aud'
-                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = 'testteam'
+        with patch.dict(
+            "sys.modules",
+            {
+                "django.contrib.auth": MagicMock(),
+                "django.contrib.auth.models": MagicMock(),
+                "django.http": MagicMock(),
+                "django.conf": MagicMock(),
+                "django.core.cache": MagicMock(),
+            },
+        ):
+            with patch("django.conf.settings") as mock_settings:
+                mock_settings.CLOUDFLARE_ACCESS_AUD = "test-aud"
+                mock_settings.CLOUDFLARE_ACCESS_TEAM_NAME = "testteam"
                 mock_settings.CLOUDFLARE_ACCESS_EXEMPT_PATHS = []
                 mock_settings.CLOUDFLARE_ACCESS_CACHE_TIMEOUT = 3600
 
-                from django_cf.middleware.CloudflareAccessMiddleware import CloudflareAccessMiddleware
+                from django_cf.middleware.CloudflareAccessMiddleware import (
+                    CloudflareAccessMiddleware,
+                )
 
                 middleware = CloudflareAccessMiddleware(lambda r: r)
 
                 key_info = {
-                    'kty': 'RSA',
-                    'kid': 'test-key-1',
-                    'n': base64url_encode(b'\x00\x01\x00\x01')
+                    "kty": "RSA",
+                    "kid": "test-key-1",
+                    "n": base64url_encode(b"\x00\x01\x00\x01"),
                     # 'e' is missing
                 }
 

--- a/packages/django-cf/tests/r2/test_storage.py
+++ b/packages/django-cf/tests/r2/test_storage.py
@@ -1,164 +1,164 @@
 import requests
 
-from ..utils import r2_web_server  # NOQA
+from ..utils import r2_web_server  # noqa: F401
 
 
 def test_r2_upload_file(r2_web_server):
     """Test uploading a file to R2 storage."""
     upload_url = f"{r2_web_server.base_url}/__r2_upload__/"
-    
+
     # Upload a test file
-    files = {'file': ('test.txt', b'Hello, R2 Storage!', 'text/plain')}
-    data = {'path': 'test_uploads/test.txt'}
+    files = {"file": ("test.txt", b"Hello, R2 Storage!", "text/plain")}
+    data = {"path": "test_uploads/test.txt"}
     response = requests.post(upload_url, files=files, data=data, timeout=10)
-    
+
     assert response.status_code == 200
     result = response.json()
-    assert result['status'] == 'success'
-    assert 'path' in result
-    assert result['path'] == 'test_uploads/test.txt'
+    assert result["status"] == "success"
+    assert "path" in result
+    assert result["path"] == "test_uploads/test.txt"
 
 
 def test_r2_download_file(r2_web_server):
     """Test downloading a file from R2 storage."""
     # First upload a file
     upload_url = f"{r2_web_server.base_url}/__r2_upload__/"
-    files = {'file': ('download_test.txt', b'Download test content', 'text/plain')}
-    data = {'path': 'test_downloads/download_test.txt'}
+    files = {"file": ("download_test.txt", b"Download test content", "text/plain")}
+    data = {"path": "test_downloads/download_test.txt"}
     upload_response = requests.post(upload_url, files=files, data=data, timeout=10)
     assert upload_response.status_code == 200
-    
+
     # Now download it
     download_url = f"{r2_web_server.base_url}/__r2_download__/"
-    params = {'path': 'test_downloads/download_test.txt'}
+    params = {"path": "test_downloads/download_test.txt"}
     response = requests.get(download_url, params=params, timeout=10)
-    
+
     assert response.status_code == 200
-    assert response.content == b'Download test content'
+    assert response.content == b"Download test content"
 
 
 def test_r2_file_exists(r2_web_server):
     """Test checking if a file exists in R2 storage."""
     # Upload a file first
     upload_url = f"{r2_web_server.base_url}/__r2_upload__/"
-    files = {'file': ('exists_test.txt', b'Exists test', 'text/plain')}
-    data = {'path': 'test_exists/exists_test.txt'}
+    files = {"file": ("exists_test.txt", b"Exists test", "text/plain")}
+    data = {"path": "test_exists/exists_test.txt"}
     upload_response = requests.post(upload_url, files=files, data=data, timeout=10)
     assert upload_response.status_code == 200
-    
+
     # Check if file exists
     exists_url = f"{r2_web_server.base_url}/__r2_exists__/"
-    params = {'path': 'test_exists/exists_test.txt'}
+    params = {"path": "test_exists/exists_test.txt"}
     response = requests.get(exists_url, params=params, timeout=10)
-    
+
     assert response.status_code == 200
     result = response.json()
-    assert result['exists'] is True
-    
+    assert result["exists"] is True
+
     # Check non-existent file
-    params = {'path': 'test_exists/nonexistent.txt'}
+    params = {"path": "test_exists/nonexistent.txt"}
     response = requests.get(exists_url, params=params, timeout=10)
-    
+
     assert response.status_code == 200
     result = response.json()
-    assert result['exists'] is False
+    assert result["exists"] is False
 
 
 def test_r2_delete_file(r2_web_server):
     """Test deleting a file from R2 storage."""
     # Upload a file first
     upload_url = f"{r2_web_server.base_url}/__r2_upload__/"
-    files = {'file': ('delete_test.txt', b'Delete me', 'text/plain')}
-    data = {'path': 'test_delete/delete_test.txt'}
+    files = {"file": ("delete_test.txt", b"Delete me", "text/plain")}
+    data = {"path": "test_delete/delete_test.txt"}
     upload_response = requests.post(upload_url, files=files, data=data, timeout=10)
     assert upload_response.status_code == 200
-    
+
     # Verify it exists
     exists_url = f"{r2_web_server.base_url}/__r2_exists__/"
-    params = {'path': 'test_delete/delete_test.txt'}
+    params = {"path": "test_delete/delete_test.txt"}
     exists_response = requests.get(exists_url, params=params, timeout=10)
-    assert exists_response.json()['exists'] is True
-    
+    assert exists_response.json()["exists"] is True
+
     # Delete the file
     delete_url = f"{r2_web_server.base_url}/__r2_delete__/"
-    data = {'path': 'test_delete/delete_test.txt'}
+    data = {"path": "test_delete/delete_test.txt"}
     response = requests.post(delete_url, data=data, timeout=10)
-    
+
     assert response.status_code == 200
     result = response.json()
-    assert result['status'] == 'success'
-    
+    assert result["status"] == "success"
+
     # Verify it no longer exists
     exists_response = requests.get(exists_url, params=params, timeout=10)
-    assert exists_response.json()['exists'] is False
+    assert exists_response.json()["exists"] is False
 
 
 def test_r2_list_files(r2_web_server):
     """Test listing files in R2 storage."""
     # Upload multiple files
     upload_url = f"{r2_web_server.base_url}/__r2_upload__/"
-    
+
     test_files = [
-        ('test_list/file1.txt', b'Content 1'),
-        ('test_list/file2.txt', b'Content 2'),
-        ('test_list/subdir/file3.txt', b'Content 3'),
+        ("test_list/file1.txt", b"Content 1"),
+        ("test_list/file2.txt", b"Content 2"),
+        ("test_list/subdir/file3.txt", b"Content 3"),
     ]
-    
+
     for path, content in test_files:
-        files = {'file': (path.split('/')[-1], content, 'text/plain')}
-        data = {'path': path}
+        files = {"file": (path.split("/")[-1], content, "text/plain")}
+        data = {"path": path}
         response = requests.post(upload_url, files=files, data=data, timeout=10)
         assert response.status_code == 200
-    
+
     # List files in test_list directory
     listdir_url = f"{r2_web_server.base_url}/__r2_listdir__/"
-    params = {'path': 'test_list'}
+    params = {"path": "test_list"}
     response = requests.get(listdir_url, params=params, timeout=10)
-    
+
     assert response.status_code == 200
     result = response.json()
-    assert 'directories' in result
-    assert 'files' in result
-    assert 'subdir' in result['directories']
-    assert 'file1.txt' in result['files']
-    assert 'file2.txt' in result['files']
+    assert "directories" in result
+    assert "files" in result
+    assert "subdir" in result["directories"]
+    assert "file1.txt" in result["files"]
+    assert "file2.txt" in result["files"]
 
 
 def test_r2_file_size(r2_web_server):
     """Test getting file size from R2 storage."""
     # Upload a file with known size
     upload_url = f"{r2_web_server.base_url}/__r2_upload__/"
-    content = b'This content has a specific size.'
-    files = {'file': ('size_test.txt', content, 'text/plain')}
-    data = {'path': 'test_size/size_test.txt'}
+    content = b"This content has a specific size."
+    files = {"file": ("size_test.txt", content, "text/plain")}
+    data = {"path": "test_size/size_test.txt"}
     upload_response = requests.post(upload_url, files=files, data=data, timeout=10)
     assert upload_response.status_code == 200
-    
+
     # Get file size
     size_url = f"{r2_web_server.base_url}/__r2_size__/"
-    params = {'path': 'test_size/size_test.txt'}
+    params = {"path": "test_size/size_test.txt"}
     response = requests.get(size_url, params=params, timeout=10)
-    
+
     assert response.status_code == 200
     result = response.json()
-    assert result['size'] == len(content)
+    assert result["size"] == len(content)
 
 
 def test_r2_content_type_preservation(r2_web_server):
     """Test that content type is preserved when uploading files."""
     upload_url = f"{r2_web_server.base_url}/__r2_upload__/"
-    
+
     # Upload a JSON file
-    files = {'file': ('data.json', b'{"key": "value"}', 'application/json')}
-    data = {'path': 'test_content_type/data.json'}
+    files = {"file": ("data.json", b'{"key": "value"}', "application/json")}
+    data = {"path": "test_content_type/data.json"}
     response = requests.post(upload_url, files=files, data=data, timeout=10)
     assert response.status_code == 200
-    
+
     # Download and check content type (if your endpoint returns it)
     download_url = f"{r2_web_server.base_url}/__r2_download__/"
-    params = {'path': 'test_content_type/data.json'}
+    params = {"path": "test_content_type/data.json"}
     response = requests.get(download_url, params=params, timeout=10)
-    
+
     assert response.status_code == 200
     assert response.content == b'{"key": "value"}'
 
@@ -166,50 +166,50 @@ def test_r2_content_type_preservation(r2_web_server):
 def test_r2_overwrite_file(r2_web_server):
     """Test overwriting an existing file in R2 storage."""
     upload_url = f"{r2_web_server.base_url}/__r2_upload__/"
-    path = 'test_overwrite/overwrite_test.txt'
-    
+    path = "test_overwrite/overwrite_test.txt"
+
     # Upload original file
-    files = {'file': ('overwrite_test.txt', b'Original content', 'text/plain')}
-    data = {'path': path}
+    files = {"file": ("overwrite_test.txt", b"Original content", "text/plain")}
+    data = {"path": path}
     response = requests.post(upload_url, files=files, data=data, timeout=10)
     assert response.status_code == 200
-    
+
     # Download and verify original content
     download_url = f"{r2_web_server.base_url}/__r2_download__/"
-    params = {'path': path}
+    params = {"path": path}
     response = requests.get(download_url, params=params, timeout=10)
-    assert response.content == b'Original content'
-    
+    assert response.content == b"Original content"
+
     # Overwrite with new content
-    files = {'file': ('overwrite_test.txt', b'New content', 'text/plain')}
-    data = {'path': path}
+    files = {"file": ("overwrite_test.txt", b"New content", "text/plain")}
+    data = {"path": path}
     response = requests.post(upload_url, files=files, data=data, timeout=10)
     assert response.status_code == 200
-    
+
     # Download and verify new content
     response = requests.get(download_url, params=params, timeout=10)
-    assert response.content == b'New content'
+    assert response.content == b"New content"
 
 
 def test_r2_empty_file(r2_web_server):
     """Test uploading and downloading an empty file."""
     upload_url = f"{r2_web_server.base_url}/__r2_upload__/"
-    
+
     # Upload empty file
-    files = {'file': ('empty.txt', b'', 'text/plain')}
-    data = {'path': 'test_empty/empty.txt'}
+    files = {"file": ("empty.txt", b"", "text/plain")}
+    data = {"path": "test_empty/empty.txt"}
     response = requests.post(upload_url, files=files, data=data, timeout=10)
     assert response.status_code == 200
-    
+
     # Download and verify it's empty
     download_url = f"{r2_web_server.base_url}/__r2_download__/"
-    params = {'path': 'test_empty/empty.txt'}
+    params = {"path": "test_empty/empty.txt"}
     response = requests.get(download_url, params=params, timeout=10)
     assert response.status_code == 200
-    assert response.content == b''
-    
+    assert response.content == b""
+
     # Check size
     size_url = f"{r2_web_server.base_url}/__r2_size__/"
     response = requests.get(size_url, params=params, timeout=10)
     assert response.status_code == 200
-    assert response.json()['size'] == 0
+    assert response.json()["size"] == 0

--- a/packages/django-cf/tests/r2/test_storage_errors.py
+++ b/packages/django-cf/tests/r2/test_storage_errors.py
@@ -1,7 +1,9 @@
 """Tests for R2 storage error handling and edge cases."""
-import pytest
-from unittest.mock import MagicMock, patch, PropertyMock
+
 from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 class TestR2StorageInitialization:
@@ -9,45 +11,52 @@ class TestR2StorageInitialization:
 
     def test_init_default_values(self):
         """Test R2Storage initializes with default values."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
 
-            assert storage.binding == 'BUCKET'
-            assert storage.location == ''
+            assert storage.binding == "BUCKET"
+            assert storage.location == ""
             assert storage.allow_overwrite is False
             assert storage._bucket is None
 
     def test_init_custom_values(self):
         """Test R2Storage initializes with custom values."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage(
-                binding='MY_BUCKET',
-                location='uploads/',
-                allow_overwrite=True
+                binding="MY_BUCKET", location="uploads/", allow_overwrite=True
             )
 
-            assert storage.binding == 'MY_BUCKET'
-            assert storage.location == 'uploads'  # Trailing slash stripped
+            assert storage.binding == "MY_BUCKET"
+            assert storage.location == "uploads"  # Trailing slash stripped
             assert storage.allow_overwrite is True
 
     def test_init_strips_slashes_from_location(self):
         """Test that leading/trailing slashes are stripped from location."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
-            storage = R2Storage(location='/uploads/files/')
+            storage = R2Storage(location="/uploads/files/")
 
-            assert storage.location == 'uploads/files'
+            assert storage.location == "uploads/files"
 
 
 class TestR2StorageFullPath:
@@ -55,27 +64,33 @@ class TestR2StorageFullPath:
 
     def test_full_path_no_location(self):
         """Test _full_path without location prefix."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
-            storage = R2Storage(location='')
-            result = storage._full_path('test/file.txt')
+            storage = R2Storage(location="")
+            result = storage._full_path("test/file.txt")
 
-            assert result == 'test/file.txt'
+            assert result == "test/file.txt"
 
     def test_full_path_with_location(self):
         """Test _full_path with location prefix."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
-            storage = R2Storage(location='uploads')
-            result = storage._full_path('test/file.txt')
+            storage = R2Storage(location="uploads")
+            result = storage._full_path("test/file.txt")
 
-            assert result == 'uploads/test/file.txt'
+            assert result == "uploads/test/file.txt"
 
 
 class TestR2StorageGetBucketErrors:
@@ -83,14 +98,17 @@ class TestR2StorageGetBucketErrors:
 
     def test_get_bucket_raises_on_non_worker(self):
         """Test _get_bucket raises exception when not in worker."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
 
-            with patch('django_cf.storage.r2.R2Storage._get_bucket') as mock_get:
+            with patch("django_cf.storage.r2.R2Storage._get_bucket") as mock_get:
                 mock_get.side_effect = Exception("Code not running inside a worker!")
 
                 with pytest.raises(Exception) as exc_info:
@@ -104,9 +122,12 @@ class TestR2StorageReadErrors:
 
     def test_read_returns_none_on_not_found(self):
         """Test _read returns None when file not found."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
@@ -116,15 +137,18 @@ class TestR2StorageReadErrors:
             storage._bucket = mock_bucket
             storage._run_sync = mock_run_sync
 
-            result = storage._read('nonexistent.txt')
+            result = storage._read("nonexistent.txt")
 
             assert result is None
 
     def test_read_returns_none_on_exception(self):
         """Test _read returns None on any exception."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
@@ -134,8 +158,8 @@ class TestR2StorageReadErrors:
             storage._bucket = mock_bucket
             storage._run_sync = mock_run_sync
             # _get_bucket will try to use the mock
-            with patch.object(storage, '_get_bucket', return_value=mock_bucket):
-                result = storage._read('file.txt')
+            with patch.object(storage, "_get_bucket", return_value=mock_bucket):
+                result = storage._read("file.txt")
 
             assert result is None
 
@@ -145,9 +169,12 @@ class TestR2StorageExistsErrors:
 
     def test_exists_returns_false_on_exception(self):
         """Test exists returns False on any exception."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
@@ -157,9 +184,8 @@ class TestR2StorageExistsErrors:
             storage._bucket = mock_bucket
             storage._run_sync = mock_run_sync
 
-
-            with patch.object(storage, '_get_bucket', return_value=mock_bucket):
-                result = storage.exists('file.txt')
+            with patch.object(storage, "_get_bucket", return_value=mock_bucket):
+                result = storage.exists("file.txt")
 
             assert result is False
 
@@ -169,9 +195,12 @@ class TestR2StorageSizeErrors:
 
     def test_size_returns_zero_on_exception(self):
         """Test size returns 0 on any exception."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
@@ -181,17 +210,19 @@ class TestR2StorageSizeErrors:
             storage._bucket = mock_bucket
             storage._run_sync = mock_run_sync
 
-
-            with patch.object(storage, '_get_bucket', return_value=mock_bucket):
-                result = storage.size('file.txt')
+            with patch.object(storage, "_get_bucket", return_value=mock_bucket):
+                result = storage.size("file.txt")
 
             assert result == 0
 
     def test_size_returns_zero_when_no_size_attribute(self):
         """Test size returns 0 when metadata has no size attribute."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
@@ -203,9 +234,8 @@ class TestR2StorageSizeErrors:
             storage._bucket = mock_bucket
             storage._run_sync = mock_run_sync
 
-
-            with patch.object(storage, '_get_bucket', return_value=mock_bucket):
-                result = storage.size('file.txt')
+            with patch.object(storage, "_get_bucket", return_value=mock_bucket):
+                result = storage.size("file.txt")
 
             assert result == 0
 
@@ -215,9 +245,12 @@ class TestR2StorageUrlErrors:
 
     def test_url_raises_without_media_url(self):
         """Test url raises ValueError when MEDIA_URL not configured."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
@@ -227,53 +260,61 @@ class TestR2StorageUrlErrors:
                 MEDIA_URL = None
 
             # Patch the import inside the url() method
-            with patch.dict('sys.modules', {'django.conf': MagicMock(settings=MockSettings())}):
+            with patch.dict(
+                "sys.modules", {"django.conf": MagicMock(settings=MockSettings())}
+            ):
                 # Need to reload to pick up the mock, but since the import is local,
                 # we just need to make sure hasattr works correctly
                 pass
 
             # Alternative approach: mock hasattr and settings directly
             mock_settings = MagicMock(spec=[])  # Empty spec = no MEDIA_URL attribute
-            with patch('django.conf.settings', mock_settings):
+            with patch("django.conf.settings", mock_settings):
                 with pytest.raises(ValueError) as exc_info:
-                    storage.url('file.txt')
+                    storage.url("file.txt")
 
                 assert "MEDIA_URL must be configured" in str(exc_info.value)
 
     def test_url_raises_with_empty_media_url(self):
         """Test url raises ValueError when MEDIA_URL is empty."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
 
             mock_settings = MagicMock()
-            mock_settings.MEDIA_URL = ''
+            mock_settings.MEDIA_URL = ""
 
-            with patch('django.conf.settings', mock_settings):
+            with patch("django.conf.settings", mock_settings):
                 with pytest.raises(ValueError) as exc_info:
-                    storage.url('file.txt')
+                    storage.url("file.txt")
 
                 assert "MEDIA_URL must be configured" in str(exc_info.value)
 
     def test_url_constructs_correct_path(self):
         """Test url constructs correct URL with MEDIA_URL."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
-            storage = R2Storage(location='uploads')
+            storage = R2Storage(location="uploads")
 
             mock_settings = MagicMock()
-            mock_settings.MEDIA_URL = '/media/'
+            mock_settings.MEDIA_URL = "/media/"
 
-            with patch('django.conf.settings', mock_settings):
-                result = storage.url('file.txt')
+            with patch("django.conf.settings", mock_settings):
+                result = storage.url("file.txt")
 
-            assert result == '/media/uploads/file.txt'
+            assert result == "/media/uploads/file.txt"
 
 
 class TestR2StorageGetModifiedTimeErrors:
@@ -281,11 +322,15 @@ class TestR2StorageGetModifiedTimeErrors:
 
     def test_get_modified_time_returns_now_on_exception(self):
         """Test get_modified_time returns current time on exception."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
-            from django_cf.storage.r2 import R2Storage
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from datetime import datetime
+
+            from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
             mock_bucket = MagicMock()
@@ -294,10 +339,9 @@ class TestR2StorageGetModifiedTimeErrors:
             storage._bucket = mock_bucket
             storage._run_sync = mock_run_sync
 
-
-            with patch.object(storage, '_get_bucket', return_value=mock_bucket):
+            with patch.object(storage, "_get_bucket", return_value=mock_bucket):
                 before = datetime.now()
-                result = storage.get_modified_time('file.txt')
+                result = storage.get_modified_time("file.txt")
                 after = datetime.now()
 
             assert before <= result <= after
@@ -308,13 +352,16 @@ class TestR2StorageGetAvailableName:
 
     def test_get_available_name_raises_on_too_long(self):
         """Test get_available_name raises exception when name too long."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
-            long_name = 'a' * 300
+            long_name = "a" * 300
 
             with pytest.raises(Exception) as exc_info:
                 storage.get_available_name(long_name, max_length=100)
@@ -323,36 +370,45 @@ class TestR2StorageGetAvailableName:
 
     def test_get_available_name_returns_original_when_allow_overwrite(self):
         """Test get_available_name returns original name when allow_overwrite."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage(allow_overwrite=True)
 
-            result = storage.get_available_name('file.txt')
+            result = storage.get_available_name("file.txt")
 
-            assert result == 'file.txt'
+            assert result == "file.txt"
 
     def test_get_available_name_returns_original_when_not_exists(self):
         """Test get_available_name returns original when file doesn't exist."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
 
-            with patch.object(storage, 'exists', return_value=False):
-                result = storage.get_available_name('file.txt')
+            with patch.object(storage, "exists", return_value=False):
+                result = storage.get_available_name("file.txt")
 
-            assert result == 'file.txt'
+            assert result == "file.txt"
 
     def test_get_available_name_increments_counter(self):
         """Test get_available_name increments counter for existing files."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
@@ -361,10 +417,10 @@ class TestR2StorageGetAvailableName:
             # 1. exists('file.txt') -> True (line 268, don't return early)
             # 2. exists('file.txt') -> True (line 275 while check, enter loop, name becomes file_1.txt)
             # 3. exists('file_1.txt') -> False (line 275 while check, exit loop)
-            with patch.object(storage, 'exists', side_effect=[True, True, False]):
-                result = storage.get_available_name('file.txt')
+            with patch.object(storage, "exists", side_effect=[True, True, False]):
+                result = storage.get_available_name("file.txt")
 
-            assert result == 'file_1.txt'
+            assert result == "file_1.txt"
 
 
 class TestR2FileClass:
@@ -372,65 +428,77 @@ class TestR2FileClass:
 
     def test_r2file_read_mode(self):
         """Test R2File in read mode."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2File
 
             mock_storage = MagicMock()
-            mock_storage._read.return_value = b'test content'
+            mock_storage._read.return_value = b"test content"
 
-            r2file = R2File('test.txt', mock_storage, mode='rb')
+            r2file = R2File("test.txt", mock_storage, mode="rb")
 
             content = r2file.read()
-            assert content == b'test content'
+            assert content == b"test content"
 
     def test_r2file_write_raises_in_read_mode(self):
         """Test R2File.write raises when in read mode."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2File
 
             mock_storage = MagicMock()
-            mock_storage._read.return_value = b''
+            mock_storage._read.return_value = b""
 
-            r2file = R2File('test.txt', mock_storage, mode='rb')
+            r2file = R2File("test.txt", mock_storage, mode="rb")
 
             with pytest.raises(AttributeError) as exc_info:
-                r2file.write(b'new content')
+                r2file.write(b"new content")
 
             assert "not opened for writing" in str(exc_info.value)
 
     def test_r2file_write_allowed_in_write_mode(self):
         """Test R2File.write works in write mode."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2File
 
             mock_storage = MagicMock()
-            mock_storage._read.return_value = b''
+            mock_storage._read.return_value = b""
 
-            r2file = R2File('test.txt', mock_storage, mode='wb')
+            r2file = R2File("test.txt", mock_storage, mode="wb")
 
             # Access file property to initialize BytesIO
             _ = r2file.file
 
-            result = r2file.write(b'new content')
+            result = r2file.write(b"new content")
             assert result == 11  # Length of 'new content'
 
     def test_r2file_close(self):
         """Test R2File.close properly closes internal file."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2File
 
             mock_storage = MagicMock()
-            mock_storage._read.return_value = b'content'
+            mock_storage._read.return_value = b"content"
 
-            r2file = R2File('test.txt', mock_storage)
+            r2file = R2File("test.txt", mock_storage)
 
             # Access file to initialize it
             _ = r2file.file
@@ -445,9 +513,12 @@ class TestR2StorageSaveEdgeCases:
 
     def test_save_with_file_like_object(self):
         """Test _save with file-like object that has read() method."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
@@ -457,21 +528,23 @@ class TestR2StorageSaveEdgeCases:
             storage._bucket = mock_bucket
             storage._run_sync = mock_run_sync
 
-
             # Create a file-like object
-            content = BytesIO(b'test content')
+            content = BytesIO(b"test content")
 
-            with patch.object(storage, '_get_bucket', return_value=mock_bucket):
-                with patch('django_cf.storage.r2.Uint8Array') as mock_uint8:
-                    result = storage._save('test.txt', content)
+            with patch.object(storage, "_get_bucket", return_value=mock_bucket):
+                with patch("django_cf.storage.r2.Uint8Array"):
+                    result = storage._save("test.txt", content)
 
-            assert result == 'test.txt'
+            assert result == "test.txt"
 
     def test_save_with_content_type(self):
         """Test _save preserves content_type when available."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
@@ -481,19 +554,15 @@ class TestR2StorageSaveEdgeCases:
             storage._bucket = mock_bucket
             storage._run_sync = mock_run_sync
 
-
             # Create a file-like object with content_type
             content = BytesIO(b'{"key": "value"}')
-            content.content_type = 'application/json'
+            content.content_type = "application/json"
 
-            with patch.object(storage, '_get_bucket', return_value=mock_bucket):
-                with patch('django_cf.storage.r2.Uint8Array') as mock_uint8:
-                    storage._save('data.json', content)
+            with patch.object(storage, "_get_bucket", return_value=mock_bucket):
+                with patch("django_cf.storage.r2.Uint8Array"):
+                    storage._save("data.json", content)
 
-            # Verify put was called with httpMetadata
-            put_call = mock_bucket.put.call_args
-            # The options dict should contain httpMetadata
-            # (exact verification depends on implementation)
+            # TODO: assert put was called with the expected httpMetadata options.
 
 
 class TestR2StorageListdirEdgeCases:
@@ -501,54 +570,58 @@ class TestR2StorageListdirEdgeCases:
 
     def test_listdir_with_empty_path(self):
         """Test listdir with empty path."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
             mock_bucket = MagicMock()
             mock_run_sync = MagicMock()
             mock_run_sync.return_value.to_py.return_value = {
-                'objects': [],
-                'delimitedPrefixes': []
+                "objects": [],
+                "delimitedPrefixes": [],
             }
 
             storage._bucket = mock_bucket
             storage._run_sync = mock_run_sync
 
-
-            with patch.object(storage, '_get_bucket', return_value=mock_bucket):
-                dirs, files = storage.listdir('')
+            with patch.object(storage, "_get_bucket", return_value=mock_bucket):
+                dirs, files = storage.listdir("")
 
             assert dirs == []
             assert files == []
 
     def test_listdir_adds_trailing_slash(self):
         """Test listdir adds trailing slash to path."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
             mock_bucket = MagicMock()
             mock_run_sync = MagicMock()
             mock_run_sync.return_value.to_py.return_value = {
-                'objects': [],
-                'delimitedPrefixes': []
+                "objects": [],
+                "delimitedPrefixes": [],
             }
 
             storage._bucket = mock_bucket
             storage._run_sync = mock_run_sync
 
-
-            with patch.object(storage, '_get_bucket', return_value=mock_bucket):
-                storage.listdir('uploads')
+            with patch.object(storage, "_get_bucket", return_value=mock_bucket):
+                storage.listdir("uploads")
 
             # Verify list was called with prefix ending in /
             list_call = mock_bucket.list.call_args
-            assert list_call[0][0]['prefix'].endswith('/')
+            assert list_call[0][0]["prefix"].endswith("/")
 
 
 class TestR2StorageTimeMethodsFallback:
@@ -556,32 +629,40 @@ class TestR2StorageTimeMethodsFallback:
 
     def test_get_accessed_time_returns_modified_time(self):
         """Test get_accessed_time falls back to get_modified_time."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
-            from django_cf.storage.r2 import R2Storage
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from datetime import datetime
+
+            from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
             mock_time = datetime(2023, 1, 15, 12, 0, 0)
 
-            with patch.object(storage, 'get_modified_time', return_value=mock_time):
-                result = storage.get_accessed_time('file.txt')
+            with patch.object(storage, "get_modified_time", return_value=mock_time):
+                result = storage.get_accessed_time("file.txt")
 
             assert result == mock_time
 
     def test_get_created_time_returns_modified_time(self):
         """Test get_created_time falls back to get_modified_time."""
-        with patch.dict('sys.modules', {
-            'js': MagicMock(),
-        }):
-            from django_cf.storage.r2 import R2Storage
+        with patch.dict(
+            "sys.modules",
+            {
+                "js": MagicMock(),
+            },
+        ):
             from datetime import datetime
+
+            from django_cf.storage.r2 import R2Storage
 
             storage = R2Storage()
             mock_time = datetime(2023, 1, 15, 12, 0, 0)
 
-            with patch.object(storage, 'get_modified_time', return_value=mock_time):
-                result = storage.get_created_time('file.txt')
+            with patch.object(storage, "get_modified_time", return_value=mock_time):
+                result = storage.get_created_time("file.txt")
 
             assert result == mock_time

--- a/packages/django-cf/tests/servers/r2/src/app/admin.py
+++ b/packages/django-cf/tests/servers/r2/src/app/admin.py
@@ -1,30 +1,37 @@
 from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
+
 from .models import BankTransaction
 
 
 @admin.register(BankTransaction)
 class BankTransactionAdmin(admin.ModelAdmin):
-    list_display = ('movement_date', 'description', 'debit', 'credit', 'balance')
-    list_filter = ('movement_date', 'created_at')
-    search_fields = ('description',)
-    readonly_fields = ('created_at', 'updated_at')
-    date_hierarchy = 'movement_date'
+    list_display = ("movement_date", "description", "debit", "credit", "balance")
+    list_filter = ("movement_date", "created_at")
+    search_fields = ("description",)
+    readonly_fields = ("created_at", "updated_at")
+    date_hierarchy = "movement_date"
 
     fieldsets = (
-        (_('Transaction Info'), {
-            'fields': ('description', 'movement_date', 'value_date')
-        }),
-        (_('Amounts'), {
-            'fields': ('balance', 'credit', 'debit')
-        }),
-        (_('Timestamps'), {
-            'fields': ('created_at', 'updated_at'),
-            'classes': ('collapse',)
-        }),
+        (
+            _("Transaction Info"),
+            {"fields": ("description", "movement_date", "value_date")},
+        ),
+        (_("Amounts"), {"fields": ("balance", "credit", "debit")}),
+        (
+            _("Timestamps"),
+            {"fields": ("created_at", "updated_at"), "classes": ("collapse",)},
+        ),
     )
 
     def get_readonly_fields(self, request, obj=None):
         if obj:
-            return self.readonly_fields + ('description', 'movement_date', 'value_date', 'balance', 'credit', 'debit')
+            return self.readonly_fields + (
+                "description",
+                "movement_date",
+                "value_date",
+                "balance",
+                "credit",
+                "debit",
+            )
         return self.readonly_fields

--- a/packages/django-cf/tests/servers/r2/src/app/asgi.py
+++ b/packages/django-cf/tests/servers/r2/src/app/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
 
 application = get_asgi_application()

--- a/packages/django-cf/tests/servers/r2/src/app/migrations/0001_initial.py
+++ b/packages/django-cf/tests/servers/r2/src/app/migrations/0001_initial.py
@@ -2,31 +2,64 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
-            name='BankTransaction',
+            name="BankTransaction",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('balance', models.DecimalField(decimal_places=2, max_digits=12, verbose_name='balance')),
-                ('credit', models.DecimalField(decimal_places=2, default=0, max_digits=12, verbose_name='credit')),
-                ('debit', models.DecimalField(decimal_places=2, default=0, max_digits=12, verbose_name='debit')),
-                ('description', models.CharField(max_length=255, verbose_name='description')),
-                ('value_date', models.DateField(verbose_name='value date')),
-                ('movement_date', models.DateField(verbose_name='movement date')),
-                ('updated_at', models.DateTimeField(auto_now=True, verbose_name='updated_at')),
-                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='created_at')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "balance",
+                    models.DecimalField(
+                        decimal_places=2, max_digits=12, verbose_name="balance"
+                    ),
+                ),
+                (
+                    "credit",
+                    models.DecimalField(
+                        decimal_places=2,
+                        default=0,
+                        max_digits=12,
+                        verbose_name="credit",
+                    ),
+                ),
+                (
+                    "debit",
+                    models.DecimalField(
+                        decimal_places=2, default=0, max_digits=12, verbose_name="debit"
+                    ),
+                ),
+                (
+                    "description",
+                    models.CharField(max_length=255, verbose_name="description"),
+                ),
+                ("value_date", models.DateField(verbose_name="value date")),
+                ("movement_date", models.DateField(verbose_name="movement date")),
+                (
+                    "updated_at",
+                    models.DateTimeField(auto_now=True, verbose_name="updated_at"),
+                ),
+                (
+                    "created_at",
+                    models.DateTimeField(auto_now_add=True, verbose_name="created_at"),
+                ),
             ],
             options={
-                'app_label': 'app',
-                'ordering': ['-movement_date', '-pk'],
-                'verbose_name': 'bank transaction',
-                'verbose_name_plural': 'bank transactions',
+                "app_label": "app",
+                "ordering": ["-movement_date", "-pk"],
+                "verbose_name": "bank transaction",
+                "verbose_name_plural": "bank transactions",
             },
         ),
     ]

--- a/packages/django-cf/tests/servers/r2/src/app/models.py
+++ b/packages/django-cf/tests/servers/r2/src/app/models.py
@@ -3,22 +3,32 @@ from django.utils.translation import gettext_lazy as _
 
 
 class BankTransaction(models.Model):
-    balance = models.DecimalField(max_digits=12, decimal_places=2, verbose_name=_('balance'))
-    credit = models.DecimalField(max_digits=12, decimal_places=2, verbose_name=_('credit'), default=0)
-    debit = models.DecimalField(max_digits=12, decimal_places=2, verbose_name=_('debit'), default=0)
-    description = models.CharField(max_length=255, verbose_name=_('description'))
+    balance = models.DecimalField(
+        max_digits=12, decimal_places=2, verbose_name=_("balance")
+    )
+    credit = models.DecimalField(
+        max_digits=12, decimal_places=2, verbose_name=_("credit"), default=0
+    )
+    debit = models.DecimalField(
+        max_digits=12, decimal_places=2, verbose_name=_("debit"), default=0
+    )
+    description = models.CharField(max_length=255, verbose_name=_("description"))
 
-    value_date = models.DateField(verbose_name=_('value date'))
-    movement_date = models.DateField(verbose_name=_('movement date'))
+    value_date = models.DateField(verbose_name=_("value date"))
+    movement_date = models.DateField(verbose_name=_("movement date"))
 
-    updated_at = models.DateTimeField(auto_now=True, auto_now_add=False, verbose_name=_('updated_at'))
-    created_at = models.DateTimeField(auto_now=False, auto_now_add=True, verbose_name=_('created_at'))
+    updated_at = models.DateTimeField(
+        auto_now=True, auto_now_add=False, verbose_name=_("updated_at")
+    )
+    created_at = models.DateTimeField(
+        auto_now=False, auto_now_add=True, verbose_name=_("created_at")
+    )
 
     def __str__(self):
         return f"{self.description} - {self.movement_date}"
 
     class Meta:
-        app_label = 'app'
+        app_label = "app"
         ordering = ["-movement_date", "-pk"]
-        verbose_name = _('bank transaction')
-        verbose_name_plural = _('bank transactions')
+        verbose_name = _("bank transaction")
+        verbose_name_plural = _("bank transactions")

--- a/packages/django-cf/tests/servers/r2/src/app/settings.py
+++ b/packages/django-cf/tests/servers/r2/src/app/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/5.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
+
 import os
 from pathlib import Path
 
@@ -20,71 +21,69 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-n+hxsvm6_5^5kx2xxe0@oq6@9laf0%&%)@du(pn6-(3enfoha_'
+SECRET_KEY = "django-insecure-n+hxsvm6_5^5kx2xxe0@oq6@9laf0%&%)@du(pn6-(3enfoha_"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
 
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'app',
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "app",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
     # 'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-ROOT_URLCONF = 'app.urls'
+ROOT_URLCONF = "app.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            BASE_DIR.joinpath('templates')
-        ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR.joinpath("templates")],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'app.wsgi.application'
+WSGI_APPLICATION = "app.wsgi.application"
 
 
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
 # Workers CI is missing the sqlite3 module, to build the staticfiles, we must disable the engine
-if os.getenv('WORKERS_CI') == "1":
+if os.getenv("WORKERS_CI") == "1":
     DATABASES = {}
 else:
     DATABASES = {
-        'default': {
-            'ENGINE': 'django_cf.db.backends.d1',
+        "default": {
+            "ENGINE": "django_cf.db.backends.d1",
             # 'CLOUDFLARE_BINDING' should match the binding name in your wrangler.toml
-            'CLOUDFLARE_BINDING': 'DB',
+            "CLOUDFLARE_BINDING": "DB",
         }
     }
 
@@ -98,7 +97,7 @@ STORAGES = {
             "binding": "BUCKET",
             "location": "",
             "allow_overwrite": True,
-        }
+        },
     },
     "staticfiles": {
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
@@ -110,16 +109,16 @@ STORAGES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
 
@@ -127,9 +126,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.1/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 USE_I18N = False
 
@@ -139,10 +138,10 @@ USE_TZ = False
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
-STATIC_URL = 'static/'
-STATIC_ROOT = BASE_DIR.parent.joinpath('staticfiles').joinpath('static')
+STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR.parent.joinpath("staticfiles").joinpath("static")
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/packages/django-cf/tests/servers/r2/src/app/urls.py
+++ b/packages/django-cf/tests/servers/r2/src/app/urls.py
@@ -14,52 +14,71 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.contrib.auth import get_user_model
-from django.core.management import call_command
-from django.http import JsonResponse, HttpResponse, HttpResponseNotFound
-from django.urls import path, include
 from django.contrib.auth.decorators import user_passes_test
-from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
-from django.db.models.functions import TruncYear, TruncMonth, TruncDay, TruncHour, TruncQuarter, TruncWeek
+from django.core.files.storage import default_storage
+from django.core.management import call_command
+from django.db.models.functions import (
+    TruncDay,
+    TruncHour,
+    TruncMonth,
+    TruncQuarter,
+    TruncWeek,
+    TruncYear,
+)
+from django.http import HttpResponse, HttpResponseNotFound, JsonResponse
+from django.urls import include, path
+
 from .models import BankTransaction
+
 
 def is_superuser(user):
     return user.is_authenticated and user.is_superuser
 
+
 # @user_passes_test(is_superuser)
 def create_admin_view(request):
     User = get_user_model()
-    username = 'admin' # Or get from request, config, etc.
-    email = 'admin@example.com' # Or get from request, config, etc.
+    username = "admin"  # Or get from request, config, etc.
+    email = "admin@example.com"  # Or get from request, config, etc.
     # IMPORTANT: Change this password or manage it securely!
-    password = 'password'
+    password = "password"
 
     if not User.objects.filter(username=username).exists():
         User.objects.create_superuser(username, email, password)
-        return JsonResponse({"status": "success", "message": f"Admin user '{username}' created."})
+        return JsonResponse(
+            {"status": "success", "message": f"Admin user '{username}' created."}
+        )
     else:
-        return JsonResponse({"status": "info", "message": f"Admin user '{username}' already exists."})
+        return JsonResponse(
+            {"status": "info", "message": f"Admin user '{username}' already exists."}
+        )
+
 
 def run_migrations_view(request):
     """Run Django migrations."""
     try:
-        call_command('migrate', verbosity=0)
+        call_command("migrate", verbosity=0)
         return JsonResponse({"status": "success", "message": "Migrations completed"})
     except Exception as e:
         return JsonResponse({"status": "error", "message": str(e)}, status=500)
 
+
 # R2 Storage Test Endpoints
 def r2_upload_view(request):
     """Test endpoint for uploading files to R2."""
-    if request.method == 'POST':
+    if request.method == "POST":
         try:
-            uploaded_file = request.FILES.get('file')
-            path = request.POST.get('path')
+            uploaded_file = request.FILES.get("file")
+            path = request.POST.get("path")
 
             if not uploaded_file or not path:
-                return JsonResponse({"status": "error", "message": "Missing file or path"}, status=400)
+                return JsonResponse(
+                    {"status": "error", "message": "Missing file or path"}, status=400
+                )
 
             # Save file to R2
             saved_path = default_storage.save(path, ContentFile(uploaded_file.read()))
@@ -68,24 +87,28 @@ def r2_upload_view(request):
         except Exception as e:
             print(str(e))
             return JsonResponse({"status": "error", "message": str(e)}, status=500)
-    return JsonResponse({"status": "error", "message": "Method not allowed"}, status=405)
+    return JsonResponse(
+        {"status": "error", "message": "Method not allowed"}, status=405
+    )
 
 
 def r2_download_view(request):
     """Test endpoint for downloading files from R2."""
-    path = request.GET.get('path')
+    path = request.GET.get("path")
 
     if not path:
-        return JsonResponse({"status": "error", "message": "Missing path parameter"}, status=400)
+        return JsonResponse(
+            {"status": "error", "message": "Missing path parameter"}, status=400
+        )
 
     try:
         if not default_storage.exists(path):
             return HttpResponseNotFound("File not found")
 
-        with default_storage.open(path, 'rb') as f:
+        with default_storage.open(path, "rb") as f:
             content = f.read()
 
-        return HttpResponse(content, content_type='application/octet-stream')
+        return HttpResponse(content, content_type="application/octet-stream")
     except Exception as e:
         print(str(e))
         return JsonResponse({"status": "error", "message": str(e)}, status=500)
@@ -93,10 +116,12 @@ def r2_download_view(request):
 
 def r2_exists_view(request):
     """Test endpoint for checking if a file exists in R2."""
-    path = request.GET.get('path')
+    path = request.GET.get("path")
 
     if not path:
-        return JsonResponse({"status": "error", "message": "Missing path parameter"}, status=400)
+        return JsonResponse(
+            {"status": "error", "message": "Missing path parameter"}, status=400
+        )
 
     try:
         exists = default_storage.exists(path)
@@ -108,24 +133,28 @@ def r2_exists_view(request):
 
 def r2_delete_view(request):
     """Test endpoint for deleting files from R2."""
-    if request.method == 'POST':
+    if request.method == "POST":
         try:
-            path = request.POST.get('path')
+            path = request.POST.get("path")
 
             if not path:
-                return JsonResponse({"status": "error", "message": "Missing path parameter"}, status=400)
+                return JsonResponse(
+                    {"status": "error", "message": "Missing path parameter"}, status=400
+                )
 
             default_storage.delete(path)
             return JsonResponse({"status": "success"})
         except Exception as e:
             print(str(e))
             return JsonResponse({"status": "error", "message": str(e)}, status=500)
-    return JsonResponse({"status": "error", "message": "Method not allowed"}, status=405)
+    return JsonResponse(
+        {"status": "error", "message": "Method not allowed"}, status=405
+    )
 
 
 def r2_listdir_view(request):
     """Test endpoint for listing files in R2."""
-    path = request.GET.get('path', '')
+    path = request.GET.get("path", "")
 
     try:
         directories, files = default_storage.listdir(path)
@@ -137,10 +166,12 @@ def r2_listdir_view(request):
 
 def r2_size_view(request):
     """Test endpoint for getting file size from R2."""
-    path = request.GET.get('path')
+    path = request.GET.get("path")
 
     if not path:
-        return JsonResponse({"status": "error", "message": "Missing path parameter"}, status=400)
+        return JsonResponse(
+            {"status": "error", "message": "Missing path parameter"}, status=400
+        )
 
     try:
         size = default_storage.size(path)
@@ -153,62 +184,70 @@ def r2_size_view(request):
 def date_trunc_test_view(request):
     """Test endpoint for date truncation functions."""
     try:
-        truncation_type = request.GET.get('type', 'month')
+        truncation_type = request.GET.get("type", "month")
 
         trunc_map = {
-            'year': TruncYear,
-            'quarter': TruncQuarter,
-            'month': TruncMonth,
-            'week': TruncWeek,
-            'day': TruncDay,
-            'hour': TruncHour,
+            "year": TruncYear,
+            "quarter": TruncQuarter,
+            "month": TruncMonth,
+            "week": TruncWeek,
+            "day": TruncDay,
+            "hour": TruncHour,
         }
 
         if truncation_type not in trunc_map:
-            return JsonResponse({
-                "status": "error",
-                "message": f"Invalid truncation type. Supported types: {', '.join(trunc_map.keys())}"
-            }, status=400)
+            return JsonResponse(
+                {
+                    "status": "error",
+                    "message": f"Invalid truncation type. Supported types: {', '.join(trunc_map.keys())}",
+                },
+                status=400,
+            )
 
         trunc_class = trunc_map[truncation_type]
 
-        results = BankTransaction.objects.annotate(
-            truncated=trunc_class('created_at')
-        ).values('truncated').distinct().order_by('truncated')
+        results = (
+            BankTransaction.objects.annotate(truncated=trunc_class("created_at"))
+            .values("truncated")
+            .distinct()
+            .order_by("truncated")
+        )
 
-        return JsonResponse({
-            "status": "success",
-            "type": truncation_type,
-            "results": [str(r['truncated']) for r in results]
-        })
+        return JsonResponse(
+            {
+                "status": "success",
+                "type": truncation_type,
+                "results": [str(r["truncated"]) for r in results],
+            }
+        )
     except Exception as e:
         import traceback
+
         traceback.print_exc()
-        return JsonResponse({
-            "status": "error",
-            "message": str(e)
-        }, status=500)
+        return JsonResponse({"status": "error", "message": str(e)}, status=500)
 
 
 def date_trunc_create_transaction_view(request):
     """Create test transactions for date truncation testing."""
     try:
-        if request.method == 'POST':
-            description = request.POST.get('description', 'Test Transaction')
-            balance = request.POST.get('balance', '100.00')
-            credit = request.POST.get('credit', '0.00')
-            debit = request.POST.get('debit', '0.00')
+        if request.method == "POST":
+            description = request.POST.get("description", "Test Transaction")
+            balance = request.POST.get("balance", "100.00")
+            credit = request.POST.get("credit", "0.00")
+            debit = request.POST.get("debit", "0.00")
             BankTransaction.objects.create(
                 description=description,
                 balance=balance,
                 credit=credit,
                 debit=debit,
-                value_date='2025-01-01',
-                movement_date='2025-01-01'
+                value_date="2025-01-01",
+                movement_date="2025-01-01",
             )
             return JsonResponse({"status": "success", "message": "Transaction created"})
 
-        return JsonResponse({"status": "error", "message": "Method not allowed"}, status=405)
+        return JsonResponse(
+            {"status": "error", "message": "Method not allowed"}, status=405
+        )
     except Exception as e:
         return JsonResponse({"status": "error", "message": str(e)}, status=500)
 
@@ -216,11 +255,15 @@ def date_trunc_create_transaction_view(request):
 def date_trunc_clear_transactions_view(request):
     """Clear all test transactions."""
     try:
-        if request.method == 'POST':
+        if request.method == "POST":
             BankTransaction.objects.all().delete()
-            return JsonResponse({"status": "success", "message": "All transactions cleared"})
+            return JsonResponse(
+                {"status": "success", "message": "All transactions cleared"}
+            )
 
-        return JsonResponse({"status": "error", "message": "Method not allowed"}, status=405)
+        return JsonResponse(
+            {"status": "error", "message": "Method not allowed"}, status=405
+        )
     except Exception as e:
         return JsonResponse({"status": "error", "message": str(e)}, status=500)
 
@@ -228,64 +271,78 @@ def date_trunc_clear_transactions_view(request):
 def test_decimal_transaction_view(request):
     """Test inserting and retrieving a transaction with decimal values."""
     try:
-        if request.method == 'POST':
+        if request.method == "POST":
             from decimal import Decimal
-            
+
             # Clear existing transactions
             BankTransaction.objects.all().delete()
-            
+
             # Create a transaction with decimal values using Decimal type
             transaction = BankTransaction.objects.create(
-                description='Decimal Test Transaction',
-                balance=Decimal('1234.56'),
-                credit=Decimal('500.75'),
-                debit=Decimal('250.19'),
-                value_date='2025-01-15',
-                movement_date='2025-01-15'
+                description="Decimal Test Transaction",
+                balance=Decimal("1234.56"),
+                credit=Decimal("500.75"),
+                debit=Decimal("250.19"),
+                value_date="2025-01-15",
+                movement_date="2025-01-15",
             )
-            
+
             # Retrieve and verify the values
             retrieved = BankTransaction.objects.get(id=transaction.id)
-            
-            return JsonResponse({
-                "status": "success",
-                "message": "Transaction created and retrieved successfully",
-                "transaction": {
-                    "id": retrieved.id,
-                    "description": retrieved.description,
-                    "balance": str(retrieved.balance),
-                    "credit": str(retrieved.credit),
-                    "debit": str(retrieved.debit),
-                    "value_date": str(retrieved.value_date),
-                    "movement_date": str(retrieved.movement_date),
+
+            return JsonResponse(
+                {
+                    "status": "success",
+                    "message": "Transaction created and retrieved successfully",
+                    "transaction": {
+                        "id": retrieved.id,
+                        "description": retrieved.description,
+                        "balance": str(retrieved.balance),
+                        "credit": str(retrieved.credit),
+                        "debit": str(retrieved.debit),
+                        "value_date": str(retrieved.value_date),
+                        "movement_date": str(retrieved.movement_date),
+                    },
                 }
-            })
-        
-        return JsonResponse({"status": "error", "message": "Method not allowed"}, status=405)
+            )
+
+        return JsonResponse(
+            {"status": "error", "message": "Method not allowed"}, status=405
+        )
     except Exception as e:
         import traceback
+
         traceback.print_exc()
         return JsonResponse({"status": "error", "message": str(e)}, status=500)
 
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-
+    path("admin/", admin.site.urls),
     # Management endpoints
-    path('__run_migrations__/', run_migrations_view, name='run_migrations'),
-    path('__create_admin__/', create_admin_view, name='create_admin'),
-
+    path("__run_migrations__/", run_migrations_view, name="run_migrations"),
+    path("__create_admin__/", create_admin_view, name="create_admin"),
     # R2 Storage Test endpoints - for testing only
-    path('__r2_upload__/', r2_upload_view, name='r2_upload'),
-    path('__r2_download__/', r2_download_view, name='r2_download'),
-    path('__r2_exists__/', r2_exists_view, name='r2_exists'),
-    path('__r2_delete__/', r2_delete_view, name='r2_delete'),
-    path('__r2_listdir__/', r2_listdir_view, name='r2_listdir'),
-    path('__r2_size__/', r2_size_view, name='r2_size'),
-
+    path("__r2_upload__/", r2_upload_view, name="r2_upload"),
+    path("__r2_download__/", r2_download_view, name="r2_download"),
+    path("__r2_exists__/", r2_exists_view, name="r2_exists"),
+    path("__r2_delete__/", r2_delete_view, name="r2_delete"),
+    path("__r2_listdir__/", r2_listdir_view, name="r2_listdir"),
+    path("__r2_size__/", r2_size_view, name="r2_size"),
     # Date truncation test endpoints
-    path('__date_trunc_test__/', date_trunc_test_view, name='date_trunc_test'),
-    path('__date_trunc_create_transaction__/', date_trunc_create_transaction_view, name='date_trunc_create_transaction'),
-    path('__date_trunc_clear_transactions__/', date_trunc_clear_transactions_view, name='date_trunc_clear_transactions'),
-    path('__test_decimal_transaction__/', test_decimal_transaction_view, name='test_decimal_transaction'),
+    path("__date_trunc_test__/", date_trunc_test_view, name="date_trunc_test"),
+    path(
+        "__date_trunc_create_transaction__/",
+        date_trunc_create_transaction_view,
+        name="date_trunc_create_transaction",
+    ),
+    path(
+        "__date_trunc_clear_transactions__/",
+        date_trunc_clear_transactions_view,
+        name="date_trunc_clear_transactions",
+    ),
+    path(
+        "__test_decimal_transaction__/",
+        test_decimal_transaction_view,
+        name="test_decimal_transaction",
+    ),
 ]

--- a/packages/django-cf/tests/servers/r2/src/app/wsgi.py
+++ b/packages/django-cf/tests/servers/r2/src/app/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
 
 application = get_wsgi_application()

--- a/packages/django-cf/tests/servers/r2/src/index.py
+++ b/packages/django-cf/tests/servers/r2/src/index.py
@@ -1,6 +1,8 @@
-from workers import WorkerEntrypoint
-from django_cf import DjangoCF
 from app.wsgi import application
+from workers import WorkerEntrypoint
+
+from django_cf import DjangoCF
+
 
 class Default(DjangoCF, WorkerEntrypoint):
     def get_app(self):

--- a/packages/django-cf/tests/servers/r2/src/manage.py
+++ b/packages/django-cf/tests/servers/r2/src/manage.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -18,5 +19,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/packages/django-cf/tests/test_date_trunc.py
+++ b/packages/django-cf/tests/test_date_trunc.py
@@ -1,188 +1,242 @@
 import requests
-from datetime import datetime, timedelta
-from .utils import r2_web_server  # NOQA
+
+from .utils import r2_web_server  # noqa: F401
 
 
 def test_date_trunc_month(r2_web_server):
     """Test truncating dates to month."""
     base_url = r2_web_server.base_url
-    
+
     # Clear any existing transactions
     requests.post(f"{base_url}/__date_trunc_clear_transactions__/", timeout=10)
-    
+
     # Create test transactions
-    requests.post(f"{base_url}/__date_trunc_create_transaction__/", data={'description': 'Transaction 1'}, timeout=10)
-    requests.post(f"{base_url}/__date_trunc_create_transaction__/", data={'description': 'Transaction 2'}, timeout=10)
-    
+    requests.post(
+        f"{base_url}/__date_trunc_create_transaction__/",
+        data={"description": "Transaction 1"},
+        timeout=10,
+    )
+    requests.post(
+        f"{base_url}/__date_trunc_create_transaction__/",
+        data={"description": "Transaction 2"},
+        timeout=10,
+    )
+
     # Test month truncation
-    response = requests.get(f"{base_url}/__date_trunc_test__/", params={'type': 'month'}, timeout=10)
-    
+    response = requests.get(
+        f"{base_url}/__date_trunc_test__/", params={"type": "month"}, timeout=10
+    )
+
     assert response.status_code == 200
     result = response.json()
-    assert result['status'] == 'success'
-    assert result['type'] == 'month'
-    assert len(result['results']) > 0
-    assert all(isinstance(r, str) for r in result['results'])
+    assert result["status"] == "success"
+    assert result["type"] == "month"
+    assert len(result["results"]) > 0
+    assert all(isinstance(r, str) for r in result["results"])
 
 
 def test_date_trunc_year(r2_web_server):
     """Test truncating dates to year."""
     base_url = r2_web_server.base_url
-    
+
     # Clear any existing transactions
     requests.post(f"{base_url}/__date_trunc_clear_transactions__/", timeout=10)
-    
+
     # Create test transactions
-    requests.post(f"{base_url}/__date_trunc_create_transaction__/", data={'description': 'Transaction 1'}, timeout=10)
-    
+    requests.post(
+        f"{base_url}/__date_trunc_create_transaction__/",
+        data={"description": "Transaction 1"},
+        timeout=10,
+    )
+
     # Test year truncation
-    response = requests.get(f"{base_url}/__date_trunc_test__/", params={'type': 'year'}, timeout=10)
-    
+    response = requests.get(
+        f"{base_url}/__date_trunc_test__/", params={"type": "year"}, timeout=10
+    )
+
     assert response.status_code == 200
     result = response.json()
-    assert result['status'] == 'success'
-    assert result['type'] == 'year'
-    assert len(result['results']) > 0
+    assert result["status"] == "success"
+    assert result["type"] == "year"
+    assert len(result["results"]) > 0
 
 
 def test_date_trunc_day(r2_web_server):
     """Test truncating dates to day."""
     base_url = r2_web_server.base_url
-    
+
     # Clear any existing transactions
     requests.post(f"{base_url}/__date_trunc_clear_transactions__/", timeout=10)
-    
+
     # Create test transactions
-    requests.post(f"{base_url}/__date_trunc_create_transaction__/", data={'description': 'Transaction 1'}, timeout=10)
-    
+    requests.post(
+        f"{base_url}/__date_trunc_create_transaction__/",
+        data={"description": "Transaction 1"},
+        timeout=10,
+    )
+
     # Test day truncation
-    response = requests.get(f"{base_url}/__date_trunc_test__/", params={'type': 'day'}, timeout=10)
-    
+    response = requests.get(
+        f"{base_url}/__date_trunc_test__/", params={"type": "day"}, timeout=10
+    )
+
     assert response.status_code == 200
     result = response.json()
-    assert result['status'] == 'success'
-    assert result['type'] == 'day'
-    assert len(result['results']) > 0
+    assert result["status"] == "success"
+    assert result["type"] == "day"
+    assert len(result["results"]) > 0
 
 
 def test_date_trunc_quarter(r2_web_server):
     """Test truncating dates to quarter."""
     base_url = r2_web_server.base_url
-    
+
     # Clear any existing transactions
     requests.post(f"{base_url}/__date_trunc_clear_transactions__/", timeout=10)
-    
+
     # Create test transactions
-    requests.post(f"{base_url}/__date_trunc_create_transaction__/", data={'description': 'Transaction 1'}, timeout=10)
-    
+    requests.post(
+        f"{base_url}/__date_trunc_create_transaction__/",
+        data={"description": "Transaction 1"},
+        timeout=10,
+    )
+
     # Test quarter truncation
-    response = requests.get(f"{base_url}/__date_trunc_test__/", params={'type': 'quarter'}, timeout=10)
-    
+    response = requests.get(
+        f"{base_url}/__date_trunc_test__/", params={"type": "quarter"}, timeout=10
+    )
+
     assert response.status_code == 200
     result = response.json()
-    assert result['status'] == 'success'
-    assert result['type'] == 'quarter'
-    assert len(result['results']) > 0
+    assert result["status"] == "success"
+    assert result["type"] == "quarter"
+    assert len(result["results"]) > 0
 
 
 def test_date_trunc_week(r2_web_server):
     """Test truncating dates to week."""
     base_url = r2_web_server.base_url
-    
+
     # Clear any existing transactions
     requests.post(f"{base_url}/__date_trunc_clear_transactions__/", timeout=10)
-    
+
     # Create test transactions
-    requests.post(f"{base_url}/__date_trunc_create_transaction__/", data={'description': 'Transaction 1'}, timeout=10)
-    
+    requests.post(
+        f"{base_url}/__date_trunc_create_transaction__/",
+        data={"description": "Transaction 1"},
+        timeout=10,
+    )
+
     # Test week truncation
-    response = requests.get(f"{base_url}/__date_trunc_test__/", params={'type': 'week'}, timeout=10)
-    
+    response = requests.get(
+        f"{base_url}/__date_trunc_test__/", params={"type": "week"}, timeout=10
+    )
+
     assert response.status_code == 200
     result = response.json()
-    assert result['status'] == 'success'
-    assert result['type'] == 'week'
-    assert len(result['results']) > 0
+    assert result["status"] == "success"
+    assert result["type"] == "week"
+    assert len(result["results"]) > 0
 
 
 def test_date_trunc_hour(r2_web_server):
     """Test truncating dates to hour."""
     base_url = r2_web_server.base_url
-    
+
     # Clear any existing transactions
     requests.post(f"{base_url}/__date_trunc_clear_transactions__/", timeout=10)
-    
+
     # Create test transactions
-    requests.post(f"{base_url}/__date_trunc_create_transaction__/", data={'description': 'Transaction 1'}, timeout=10)
-    
+    requests.post(
+        f"{base_url}/__date_trunc_create_transaction__/",
+        data={"description": "Transaction 1"},
+        timeout=10,
+    )
+
     # Test hour truncation
-    response = requests.get(f"{base_url}/__date_trunc_test__/", params={'type': 'hour'}, timeout=10)
-    
+    response = requests.get(
+        f"{base_url}/__date_trunc_test__/", params={"type": "hour"}, timeout=10
+    )
+
     assert response.status_code == 200
     result = response.json()
-    assert result['status'] == 'success'
-    assert result['type'] == 'hour'
-    assert len(result['results']) > 0
+    assert result["status"] == "success"
+    assert result["type"] == "hour"
+    assert len(result["results"]) > 0
 
 
 def test_date_trunc_invalid_type(r2_web_server):
     """Test that invalid truncation type returns error."""
     base_url = r2_web_server.base_url
-    
+
     # Test invalid truncation type
-    response = requests.get(f"{base_url}/__date_trunc_test__/", params={'type': 'invalid'}, timeout=10)
-    
+    response = requests.get(
+        f"{base_url}/__date_trunc_test__/", params={"type": "invalid"}, timeout=10
+    )
+
     assert response.status_code == 400
     result = response.json()
-    assert result['status'] == 'error'
-    assert 'Invalid truncation type' in result['message']
+    assert result["status"] == "error"
+    assert "Invalid truncation type" in result["message"]
 
 
 def test_date_trunc_create_and_clear_transactions(r2_web_server):
     """Test creating and clearing transactions."""
     base_url = r2_web_server.base_url
-    
+
     # Clear any existing transactions
-    response = requests.post(f"{base_url}/__date_trunc_clear_transactions__/", timeout=10)
+    response = requests.post(
+        f"{base_url}/__date_trunc_clear_transactions__/", timeout=10
+    )
     assert response.status_code == 200
-    assert response.json()['status'] == 'success'
-    
+    assert response.json()["status"] == "success"
+
     # Create a transaction
-    response = requests.post(f"{base_url}/__date_trunc_create_transaction__/", data={'description': 'Test Transaction'}, timeout=10)
+    response = requests.post(
+        f"{base_url}/__date_trunc_create_transaction__/",
+        data={"description": "Test Transaction"},
+        timeout=10,
+    )
     assert response.status_code == 200
-    assert response.json()['status'] == 'success'
-    
+    assert response.json()["status"] == "success"
+
     # Verify transaction was created by querying
-    response = requests.get(f"{base_url}/__date_trunc_test__/", params={'type': 'month'}, timeout=10)
+    response = requests.get(
+        f"{base_url}/__date_trunc_test__/", params={"type": "month"}, timeout=10
+    )
     assert response.status_code == 200
-    assert len(response.json()['results']) > 0
-    
+    assert len(response.json()["results"]) > 0
+
     # Clear transactions
-    response = requests.post(f"{base_url}/__date_trunc_clear_transactions__/", timeout=10)
+    response = requests.post(
+        f"{base_url}/__date_trunc_clear_transactions__/", timeout=10
+    )
     assert response.status_code == 200
-    
+
     # Verify transactions were cleared
-    response = requests.get(f"{base_url}/__date_trunc_test__/", params={'type': 'month'}, timeout=10)
+    response = requests.get(
+        f"{base_url}/__date_trunc_test__/", params={"type": "month"}, timeout=10
+    )
     assert response.status_code == 200
-    assert len(response.json()['results']) == 0
+    assert len(response.json()["results"]) == 0
 
 
 def test_decimal_transaction(r2_web_server):
     """Test inserting and retrieving a transaction with decimal values."""
     base_url = r2_web_server.base_url
-    
+
     # Test decimal transaction creation and retrieval
     response = requests.post(f"{base_url}/__test_decimal_transaction__/", timeout=10)
-    
+
     assert response.status_code == 200
     result = response.json()
-    assert result['status'] == 'success'
-    assert 'transaction' in result
-    
-    transaction = result['transaction']
-    assert transaction['description'] == 'Decimal Test Transaction'
-    assert transaction['balance'] == '1234.56'
-    assert transaction['credit'] == '500.75'
-    assert transaction['debit'] == '250.19'
-    assert transaction['value_date'] == '2025-01-15'
-    assert transaction['movement_date'] == '2025-01-15'
+    assert result["status"] == "success"
+    assert "transaction" in result
+
+    transaction = result["transaction"]
+    assert transaction["description"] == "Decimal Test Transaction"
+    assert transaction["balance"] == "1234.56"
+    assert transaction["credit"] == "500.75"
+    assert transaction["debit"] == "250.19"
+    assert transaction["value_date"] == "2025-01-15"
+    assert transaction["movement_date"] == "2025-01-15"

--- a/packages/django-cf/tests/test_wsgi_handler.py
+++ b/packages/django-cf/tests/test_wsgi_handler.py
@@ -1,5 +1,7 @@
 """Tests for WSGI handler and DjangoCF classes."""
+
 import pytest
+
 from django_cf import DjangoCF, DjangoCFDurableObject
 
 
@@ -12,13 +14,17 @@ class TestDjangoCFErrorMessages:
         with pytest.raises(NotImplementedError) as exc_info:
             cf.get_app()
         # Verify no duplicate "implement" word
-        assert str(exc_info.value) == "Please implement get_app in your django_cf worker"
+        assert (
+            str(exc_info.value) == "Please implement get_app in your django_cf worker"
+        )
         assert "implement implement" not in str(exc_info.value)
 
     def test_djangocf_durable_object_get_app_error_message(self):
         """Test that DjangoCFDurableObject.get_app() raises NotImplementedError with correct message."""
         # DjangoCFDurableObject.__init__ requires ctx and env, so test get_app directly
-        assert "implement get_app" in DjangoCFDurableObject.get_app.__code__.co_consts[1]
+        assert (
+            "implement get_app" in DjangoCFDurableObject.get_app.__code__.co_consts[1]
+        )
         # Verify no duplicate word in the source constant
         for const in DjangoCFDurableObject.get_app.__code__.co_consts:
             if isinstance(const, str) and "implement" in const:
@@ -38,6 +44,7 @@ class TestWSGIHeaderTransformation:
     def test_header_transformation_replaces_dashes(self):
         """Verify the header transformation code replaces dashes with underscores."""
         import inspect
+
         from django_cf import handle_wsgi
 
         source = inspect.getsource(handle_wsgi)
@@ -57,7 +64,7 @@ class TestWSGIHeaderTransformation:
             ("cf-connecting-ip", "HTTP_CF_CONNECTING_IP"),
         ]
         for header_name, expected_key in test_cases:
-            result = f'HTTP_{header_name.upper().replace("-", "_")}'
+            result = f"HTTP_{header_name.upper().replace('-', '_')}"
             assert result == expected_key, (
                 f"Header '{header_name}' should map to '{expected_key}', got '{result}'"
             )

--- a/packages/django-cf/tests/utils.py
+++ b/packages/django-cf/tests/utils.py
@@ -28,14 +28,16 @@ class WorkerFixture:
         self.base_url = f"http://localhost:{self.port}"
 
         # Clean up previous wrangler state
-        wrangler_state_dir = os.path.join(worker_dir, '.wrangler')
+        wrangler_state_dir = os.path.join(worker_dir, ".wrangler")
         if os.path.exists(wrangler_state_dir):
-            subprocess.run(['rm', '-rf', wrangler_state_dir], cwd=worker_dir, check=True)
+            subprocess.run(
+                ["rm", "-rf", wrangler_state_dir], cwd=worker_dir, check=True
+            )
 
         cmd_parts = ["npx", "wrangler", "dev", "--port", str(self.port)]
         self.process = subprocess.Popen(
             cmd_parts,
-            cwd=worker_dir, # Run npx from the worker directory
+            cwd=worker_dir,  # Run npx from the worker directory
             preexec_fn=os.setsid,  # So we can kill the process group later
         )
 
@@ -75,7 +77,9 @@ class WorkerFixture:
 @pytest.fixture(scope="session")
 def durable_objects_web_server():
     """Pytest fixture that starts the worker for the entire test session."""
-    worker_dir = os.path.join(os.path.dirname(__file__), '..', 'templates', 'durable-objects')
+    worker_dir = os.path.join(
+        os.path.dirname(__file__), "..", "templates", "durable-objects"
+    )
     server = WorkerFixture()
     server.start(worker_dir)
 
@@ -86,7 +90,7 @@ def durable_objects_web_server():
 @pytest.fixture(scope="session")
 def d1_web_server():
     """Pytest fixture that starts the worker for the entire test session."""
-    worker_dir = os.path.join(os.path.dirname(__file__), '..', 'templates', 'd1')
+    worker_dir = os.path.join(os.path.dirname(__file__), "..", "templates", "d1")
     server = WorkerFixture()
     server.start(worker_dir)
 
@@ -97,7 +101,7 @@ def d1_web_server():
 @pytest.fixture(scope="session")
 def r2_web_server():
     """Pytest fixture that starts the R2 test server for the entire test session."""
-    worker_dir = os.path.join(os.path.dirname(__file__), 'servers', 'r2')
+    worker_dir = os.path.join(os.path.dirname(__file__), "servers", "r2")
     server = WorkerFixture()
     server.start(worker_dir)
 


### PR DESCRIPTION
Apply the same linter settings to other two packages in this repository. This change is mostly mechanical and NFC.

- Apply ruff (mypy and semgrep is not applied yet)
- Test directories are excluded for now.