### PR TITLE
fix(django-cf): fix binding results type conversions

### DIFF
--- a/packages/django-cf/django_cf/db/backends/d1/base.py
+++ b/packages/django-cf/django_cf/db/backends/d1/base.py
@@ -80,25 +80,17 @@ class DatabaseWrapper(CFDatabaseWrapper):
         else:
             stmt = db.prepare(proc_query)
 
-        read_only = is_read_only_query(proc_query)
-        try:
-            if read_only:
-                response = self.run_sync(stmt.raw()).to_py()
-                result = CFResult.from_object(query, params, response, len(response), 0)
-            else:
-                response = self.run_sync(stmt.all())
-                result = CFResult.from_object(
-                    query,
-                    params,
-                    response.results.to_py(),
-                    response.meta.rows_read,
-                    response.meta.rows_written,
-                    response.meta.last_row_id,
-                )
-        except Exception:
-            from js import Error
+        if is_read_only_query(proc_query):
+            response = self.run_sync(stmt.raw())
+            return CFResult.from_object(query, params, response, len(response), 0)
 
-            Error.stackTraceLimit = 1e10
-            raise Error(Error.new().stack)
-
-        return result
+        response = self.run_sync(stmt.all())
+        meta = response["meta"]
+        return CFResult.from_object(
+            query,
+            params,
+            response["results"],
+            meta["rows_read"],
+            meta["rows_written"],
+            meta["last_row_id"],
+        )

--- a/packages/django-cf/django_cf/db/backends/do/base.py
+++ b/packages/django-cf/django_cf/db/backends/do/base.py
@@ -45,15 +45,7 @@ class DatabaseWrapper(CFDatabaseWrapper):
         else:
             stmt = db.exec(proc_query)
 
-        try:
-            response = stmt.raw().toArray().to_py()
-            result = CFResult.from_object(
-                query, params, response, stmt.rowsRead, stmt.rowsWritten
-            )
-        except Exception:
-            from js import Error
-
-            Error.stackTraceLimit = 1e10
-            raise Error(Error.new().stack)
-
-        return result
+        response = stmt.raw().toArray().to_py()
+        return CFResult.from_object(
+            query, params, response, stmt.rowsRead, stmt.rowsWritten
+        )

--- a/packages/django-cf/django_cf/storage/r2.py
+++ b/packages/django-cf/django_cf/storage/r2.py
@@ -115,7 +115,7 @@ class R2Storage(Storage):
             if r2_object is None:
                 return None
 
-            return self._run_sync(r2_object.arrayBuffer()).to_bytes()
+            return bytes(self._run_sync(r2_object.arrayBuffer()))
         except Exception:
             return None
 
@@ -174,9 +174,7 @@ class R2Storage(Storage):
             full_path += "/"
 
         bucket = self._get_bucket()
-        result = self._run_sync(
-            bucket.list({"prefix": full_path, "delimiter": "/"})
-        ).to_py()
+        result = self._run_sync(bucket.list({"prefix": full_path, "delimiter": "/"}))
 
         directories = []
         files = []
@@ -189,8 +187,6 @@ class R2Storage(Storage):
 
         objects = result.get("objects", [])
         for obj in objects:
-            _obj = obj.to_py()
-
             if not obj.key.endswith("/"):
                 files.append(os.path.basename(obj.key))
 

--- a/packages/django-cf/tests/db/test_d1_backend.py
+++ b/packages/django-cf/tests/db/test_d1_backend.py
@@ -1,6 +1,7 @@
 """Tests for django_cf/db/backends/d1/base.py - D1 database backend."""
 
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -220,25 +221,28 @@ class TestD1GetConnectionParams:
 class TestD1ExceptionHandling:
     """Tests for D1 backend exception handling."""
 
-    def test_run_query_uses_except_exception(self):
-        """Test that run_query uses 'except Exception' instead of bare 'except'.
+    def test_run_query_lets_binding_errors_propagate(self):
+        """run_query must not catch errors raised by the D1 binding.
 
-        Bare except clauses catch BaseException subclasses like KeyboardInterrupt
-        and SystemExit, which should be allowed to propagate normally.
+        It used to catch everything and re-raise a bare ``js.Error`` carrying only
+        a JavaScript stack, which discarded the Python exception. That is how the
+        eager-conversion break stayed invisible: every failure looked like the
+        same opaque wasm trace.
         """
+        import ast
         import importlib.util
 
         spec = importlib.util.find_spec("django_cf.db.backends.d1.base")
-        with open(spec.origin) as f:
-            content = f.read()
-            # Should use 'except Exception:' not bare 'except:'
-            assert "except Exception:" in content
-            # Should NOT have bare except (except inside 'except Exception')
-            lines = content.split("\n")
-            for line in lines:
-                stripped = line.strip()
-                if stripped.startswith("except") and stripped.endswith(":"):
-                    assert stripped != "except:", f"Found bare 'except:' clause: {line}"
+        tree = ast.parse(Path(spec.origin).read_text())
+
+        run_query = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "run_query"
+        )
+        handlers = [n for n in ast.walk(run_query) if isinstance(n, ast.ExceptHandler)]
+
+        assert handlers == []
 
 
 class TestD1ParameterHandling:

--- a/packages/django-cf/tests/db/test_do_backend.py
+++ b/packages/django-cf/tests/db/test_do_backend.py
@@ -1,5 +1,6 @@
 """Tests for django_cf/db/backends/do/base.py - Durable Objects database backend."""
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 
@@ -221,51 +222,32 @@ class TestDOQueryExecution:
         result = mock_run_query("SELECT * FROM users", is_read=True)
         assert result == []
 
-    def test_error_handling_exposes_stack(self):
-        """
-        Test documenting that DO backend exposes full stack traces.
-
-        This is a potential security issue - stack traces should not
-        be exposed in production errors.
-        """
-        # The DO backend has this pattern:
-        # except:
-        #     from js import Error
-        #     Error.stackTraceLimit = 1e10
-        #     raise Error(Error.new().stack)
-
-        import importlib.util
-
-        spec = importlib.util.find_spec("django_cf.db.backends.do.base")
-        with open(spec.origin) as f:
-            content = f.read()
-            # Verify the problematic pattern exists
-            assert "Error.stackTraceLimit = 1e10" in content
-            assert "raise Error(Error.new().stack)" in content
-
 
 class TestDOExceptionHandling:
     """Tests for DO backend exception handling."""
 
-    def test_run_query_uses_except_exception(self):
-        """Test that run_query uses 'except Exception' instead of bare 'except'.
+    def test_run_query_lets_binding_errors_propagate(self):
+        """run_query must not catch errors raised by the Durable Object binding.
 
-        Bare except clauses catch BaseException subclasses like KeyboardInterrupt
-        and SystemExit, which should be allowed to propagate normally.
+        It used to catch everything and re-raise a bare ``js.Error`` carrying only
+        a JavaScript stack, which discarded the Python exception. That is how a
+        real backend break stayed invisible: every failure looked like the same
+        opaque wasm trace.
         """
+        import ast
         import importlib.util
 
         spec = importlib.util.find_spec("django_cf.db.backends.do.base")
-        with open(spec.origin) as f:
-            content = f.read()
-            # Should use 'except Exception:' not bare 'except:'
-            assert "except Exception:" in content
-            # Should NOT have bare except
-            lines = content.split("\n")
-            for line in lines:
-                stripped = line.strip()
-                if stripped.startswith("except") and stripped.endswith(":"):
-                    assert stripped != "except:", f"Found bare 'except:' clause: {line}"
+        tree = ast.parse(Path(spec.origin).read_text())
+
+        run_query = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "run_query"
+        )
+        handlers = [n for n in ast.walk(run_query) if isinstance(n, ast.ExceptHandler)]
+
+        assert handlers == []
 
 
 class TestDOParamConversion:


### PR DESCRIPTION
Removed extra `to_py()` or other conversion logics from django-cf. I have updated our rpc calls in sdk to do these conversions internally so that users will only see the Python objects whenever possible.

I also dropped the DO-backend behavior that were exposing JS stacks to the user, which is not useful.

These changes are mostly to make the existing unittests pass, not to actually introduce new features.