### PR TITLE
fix: Make wsgi streaming response handlers async

### DIFF
--- a/packages/runtime-sdk/src/workers/wsgi.py
+++ b/packages/runtime-sdk/src/workers/wsgi.py
@@ -262,8 +262,9 @@ def _make_streaming_response(
             for proxy in proxies:
                 proxy.destroy()
 
+    # Make proxies async so that it is possible to stack switch inside them.
     @create_proxy
-    def pull(controller: Any) -> None:
+    async def pull(controller: Any) -> None:
         try:
             chunk = next(chunks, _END)
         except Exception as exc:  # noqa: BLE001 - forward app errors to the stream
@@ -278,7 +279,7 @@ def _make_streaming_response(
         controller.enqueue(_to_js_uint8array(chunk))
 
     @create_proxy
-    def cancel(_reason: Any = None) -> None:
+    async def cancel(_reason: Any = None) -> None:
         cleanup()
 
     proxies = [pull, cancel]

--- a/packages/runtime-sdk/tests/workerd-test/wsgi/tests/test_wsgi.py
+++ b/packages/runtime-sdk/tests/workerd-test/wsgi/tests/test_wsgi.py
@@ -62,9 +62,10 @@ async def test_cookies():
     assert "b=2" in cookies
 
 
+@pytest.mark.parametrize("endpoint", ("stream", "stream-stack-switch"))
 @pytest.mark.asyncio
-async def test_streaming():
-    response = await env.SELF.fetch("http://example.com/stream")
+async def test_streaming(endpoint):
+    response = await env.SELF.fetch("http://example.com/" + endpoint)
     assert response.status == 200
     assert response.headers.get("content-type") == "application/octet-stream"
 

--- a/packages/runtime-sdk/tests/workerd-test/wsgi/worker.py
+++ b/packages/runtime-sdk/tests/workerd-test/wsgi/worker.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 import pytest
+from pyodide.ffi import run_sync
 from pyodide.webloop import WebLoop
 
 from workers import WorkerEntrypoint, wsgi
@@ -96,6 +97,18 @@ def streaming_app(environ, start_response):
     return generate()
 
 
+def streaming_app_stack_switch(environ, start_response):
+    """WSGI app that returns multiple body chunks via a generator."""
+    start_response("200 OK", [("Content-Type", "application/octet-stream")])
+
+    def generate():
+        for i in range(STREAMING_NUM_CHUNKS):
+            run_sync(asyncio.sleep(0))
+            yield bytes([i % 256]) * STREAMING_CHUNK_SIZE
+
+    return generate()
+
+
 def crash_app(environ, start_response):
     raise RuntimeError("app crash before response for testing")
 
@@ -112,16 +125,15 @@ class Default(WorkerEntrypoint):
         url = URL.new(request.url)
         path = url.pathname
 
-        if path == "/echo-body":
-            return await wsgi.fetch(echo_body_app, request, self.env)
-        elif path == "/meta":
-            return await wsgi.fetch(echo_meta_app, request, self.env)
-        elif path == "/cookies":
-            return await wsgi.fetch(cookies_app, request, self.env)
-        elif path == "/stream":
-            return await wsgi.fetch(streaming_app, request, self.env)
+        app = {
+            "/echo-body": echo_body_app,
+            "/meta": echo_meta_app,
+            "/cookies": cookies_app,
+            "/stream": streaming_app,
+            "/stream-stack-switch": streaming_app_stack_switch,
+        }.get(path, header_echo_app)
 
-        return await wsgi.fetch(header_echo_app, request, self.env)
+        return await wsgi.fetch(app, request, self.env)
 
     async def test(self, ctrl):
         os.chdir("/session/metadata/tests")


### PR DESCRIPTION
So it's possible to stack switch inside of them. Also, make sure that contextvars are preserved.

On top of #189.