### PR TITLE
test(django-cf): use real d1 and durable objects instead of mocks

### DIFF
--- a/packages/django-cf/tests/in_worker/worker/pyproject.toml
+++ b/packages/django-cf/tests/in_worker/worker/pyproject.toml
@@ -5,5 +5,6 @@ requires-python = ">=3.12"
 dependencies = [
     "django<6.1",
     "pytest",
+    "pytest-asyncio<1.2.0",
     "sqlparse",
 ]

--- a/packages/django-cf/tests/in_worker/worker/src/test_d1_backend.py
+++ b/packages/django-cf/tests/in_worker/worker/src/test_d1_backend.py
@@ -2,61 +2,15 @@
 
 # pyright: reportMissingImports=false
 
-from types import SimpleNamespace
-
 import pytest
-import workers
+from django.db import connections
 
-
-def make_d1_wrapper(defer_foreign_keys=False):
-    from django_cf.db.backends.d1.base import DatabaseWrapper
-
-    wrapper = DatabaseWrapper.__new__(DatabaseWrapper)
-    cursor_state = SimpleNamespace(_defer_foreign_keys=defer_foreign_keys)
-    wrapper.cursor = lambda: cursor_state
-    wrapper.binding = "DB"
-    wrapper.run_sync = lambda value: value
-    return wrapper
-
-
-class FakeD1Statement:
-    def __init__(
-        self, *, raw_result=None, all_result=None, raw_error=None, all_error=None
-    ):
-        self.raw_result = raw_result or []
-        self.all_result = all_result or {"results": [], "meta": {}}
-        self.raw_error = raw_error
-        self.all_error = all_error
-        self.bound_params = None
-
-    def bind(self, *params):
-        self.bound_params = params
-        return self
-
-    def raw(self):
-        if self.raw_error is not None:
-            raise self.raw_error
-        return self.raw_result
-
-    def all(self):
-        if self.all_error is not None:
-            raise self.all_error
-        return self.all_result
-
-
-class FakeD1Binding:
-    def __init__(self, statement):
-        self.statement = statement
-        self.prepared_queries = []
-
-    def prepare(self, query):
-        self.prepared_queries.append(query)
-        return self.statement
+D1_BACKEND = connections["d1"]
 
 
 class TestD1DatabaseWrapperProcessQuery:
     def test_process_query_no_params(self):
-        wrapper = make_d1_wrapper()
+        wrapper = D1_BACKEND
 
         result_query, result_params = wrapper.process_query(
             "SELECT * FROM users WHERE id = %s", None
@@ -66,7 +20,7 @@ class TestD1DatabaseWrapperProcessQuery:
         assert result_params is None
 
     def test_process_query_with_params(self):
-        wrapper = make_d1_wrapper()
+        wrapper = D1_BACKEND
 
         result_query, result_params = wrapper.process_query(
             "SELECT * FROM users WHERE id = %s AND name = %s", [1, "test"]
@@ -76,7 +30,7 @@ class TestD1DatabaseWrapperProcessQuery:
         assert result_params == [1, "test"]
 
     def test_process_query_null_param_replaced_with_literal(self):
-        wrapper = make_d1_wrapper()
+        wrapper = D1_BACKEND
 
         result_query, result_params = wrapper.process_query(
             "INSERT INTO users (name, email) VALUES (%s, %s)", ["test", None]
@@ -86,7 +40,7 @@ class TestD1DatabaseWrapperProcessQuery:
         assert result_params == ["test"]
 
     def test_process_query_all_null_params(self):
-        wrapper = make_d1_wrapper()
+        wrapper = D1_BACKEND
 
         result_query, result_params = wrapper.process_query(
             "INSERT INTO users (name, email) VALUES (%s, %s)", [None, None]
@@ -96,7 +50,7 @@ class TestD1DatabaseWrapperProcessQuery:
         assert result_params == []
 
     def test_process_query_mixed_params(self):
-        wrapper = make_d1_wrapper()
+        wrapper = D1_BACKEND
 
         result_query, result_params = wrapper.process_query(
             "UPDATE users SET name = %s, email = %s, age = %s WHERE id = %s",
@@ -108,15 +62,20 @@ class TestD1DatabaseWrapperProcessQuery:
         assert result_query.count("null") == 2
 
     def test_process_query_with_defer_foreign_keys(self):
-        result = make_d1_wrapper(True).process_query(
-            "INSERT INTO users (name) VALUES (%s)", ["test"]
-        )
+        cursor = D1_BACKEND.cursor()
+        cursor.defer_foreign_keys(True)
+        try:
+            result = D1_BACKEND.process_query(
+                "INSERT INTO users (name) VALUES (%s)", ["test"]
+            )
+        finally:
+            cursor.defer_foreign_keys(False)
 
         assert "PRAGMA defer_foreign_keys = on" in result
         assert "PRAGMA defer_foreign_keys = off" in result
 
     def test_process_query_date_trunc_replacement(self):
-        wrapper = make_d1_wrapper()
+        wrapper = D1_BACKEND
 
         result_query, _ = wrapper.process_query(
             "SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders",
@@ -143,8 +102,9 @@ class TestD1GetConnectionParams:
     def test_missing_binding_raises_error(self):
         from django.core.exceptions import ImproperlyConfigured
 
-        wrapper = make_d1_wrapper()
-        wrapper.settings_dict = {"CLOUDFLARE_BINDING": None}
+        from django_cf.db.backends.d1.base import DatabaseWrapper
+
+        wrapper = DatabaseWrapper({"CLOUDFLARE_BINDING": None}, "missing-binding")
 
         with pytest.raises(ImproperlyConfigured) as exc_info:
             wrapper.get_connection_params()
@@ -152,10 +112,7 @@ class TestD1GetConnectionParams:
         assert "CLOUDFLARE_BINDING" in str(exc_info.value)
 
     def test_valid_binding_returns_params(self):
-        wrapper = make_d1_wrapper()
-        wrapper.settings_dict = {"CLOUDFLARE_BINDING": "MY_DB"}
-
-        assert wrapper.get_connection_params() == {"binding": "MY_DB"}
+        assert D1_BACKEND.get_connection_params() == {"binding": "DB"}
 
 
 class TestD1ExceptionHandling:
@@ -165,54 +122,48 @@ class TestD1ExceptionHandling:
         ),
         strict=True,
     )
-    def test_run_query_lets_binding_errors_propagate(self, monkeypatch):
-        wrapper = make_d1_wrapper()
-        error = RuntimeError("binding boom")
-        monkeypatch.setattr(
-            workers,
-            "env",
-            SimpleNamespace(DB=FakeD1Binding(FakeD1Statement(raw_error=error))),
-        )
+    def test_run_query_lets_binding_errors_propagate(self):
+        wrapper = D1_BACKEND
 
-        with pytest.raises(RuntimeError, match="binding boom"):
-            wrapper.run_query("SELECT * FROM test")
+        with pytest.raises(Exception, match="no such table"):
+            wrapper.run_query("SELECT * FROM _django_cf_d1_missing_table")
 
 
 class TestD1RunQuery:
-    def test_read_query_returns_rows(self, monkeypatch):
-        wrapper = make_d1_wrapper()
-        statement = FakeD1Statement(raw_result=[[1, "hello"], [2, "world"]])
-        binding = FakeD1Binding(statement)
-        monkeypatch.setattr(workers, "env", SimpleNamespace(DB=binding))
+    def test_read_query_returns_rows(self):
+        wrapper = D1_BACKEND
+        table = "_django_cf_d1_read"
+        wrapper.run_query(f"DROP TABLE IF EXISTS {table}")
+        wrapper.run_query(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY, value TEXT)")
+        wrapper.run_query(f"INSERT INTO {table} VALUES (%s, %s)", [1, "hello"])
+        wrapper.run_query(f"INSERT INTO {table} VALUES (%s, %s)", [2, "world"])
 
-        result = wrapper.run_query("SELECT * FROM test WHERE id = %s", [1])
+        result = wrapper.run_query(
+            f"SELECT id, value FROM {table} WHERE id >= %s ORDER BY id", [1]
+        )
 
         assert list(result) == [(1, "hello"), (2, "world")]
-        assert statement.bound_params == (1,)
-        assert binding.prepared_queries == ["SELECT * FROM test WHERE id = ?"]
+        wrapper.run_query(f"DROP TABLE {table}")
 
-    def test_write_query_returns_meta(self, monkeypatch):
-        wrapper = make_d1_wrapper()
-        statement = FakeD1Statement(
-            all_result={
-                "results": [["ok"]],
-                "meta": {"rows_read": 1, "rows_written": 2, "last_row_id": 9},
-            }
-        )
-        monkeypatch.setattr(
-            workers, "env", SimpleNamespace(DB=FakeD1Binding(statement))
+    def test_write_query_returns_meta(self):
+        wrapper = D1_BACKEND
+        table = "_django_cf_d1_write"
+        wrapper.run_query(f"DROP TABLE IF EXISTS {table}")
+        wrapper.run_query(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY, value TEXT)")
+
+        result = wrapper.run_query(
+            f"INSERT INTO {table} (id, value) VALUES (%s, %s)", [1, "x"]
         )
 
-        result = wrapper.run_query("INSERT INTO test VALUES (%s)", ["x"])
-
-        assert list(result) == [("ok",)]
-        assert result.rowcount == 2
-        assert result.lastrowid == 9
+        assert list(result) == []
+        assert result.rowcount == 1
+        assert result.lastrowid == 1
+        wrapper.run_query(f"DROP TABLE {table}")
 
 
 class TestD1ParameterHandling:
     def test_empty_params_list(self):
-        wrapper = make_d1_wrapper()
+        wrapper = D1_BACKEND
 
         result_query, result_params = wrapper.process_query("SELECT * FROM users", [])
 
@@ -220,7 +171,7 @@ class TestD1ParameterHandling:
         assert result_params == []
 
     def test_special_characters_in_params(self):
-        wrapper = make_d1_wrapper()
+        wrapper = D1_BACKEND
 
         result_query, result_params = wrapper.process_query(
             "INSERT INTO users (name) VALUES (%s)", ["test'; DROP TABLE users; --"]
@@ -230,7 +181,7 @@ class TestD1ParameterHandling:
         assert "?" in result_query
 
     def test_unicode_params(self):
-        wrapper = make_d1_wrapper()
+        wrapper = D1_BACKEND
 
         _, result_params = wrapper.process_query(
             "INSERT INTO users (name) VALUES (%s)", [""]
@@ -239,7 +190,7 @@ class TestD1ParameterHandling:
         assert result_params == [""]
 
     def test_large_number_of_params(self):
-        wrapper = make_d1_wrapper()
+        wrapper = D1_BACKEND
 
         placeholders = ", ".join(["%s"] * 50)
         result_query, result_params = wrapper.process_query(

--- a/packages/django-cf/tests/in_worker/worker/src/test_do_backend.py
+++ b/packages/django-cf/tests/in_worker/worker/src/test_do_backend.py
@@ -2,68 +2,22 @@
 
 # pyright: reportMissingImports=false
 
-from types import SimpleNamespace
-
 import pytest
+from django.db import connections
+
+D1_BACKEND = connections["d1"]
+DO_BACKEND = connections["do"]
 
 
-def make_d1_wrapper(defer_foreign_keys=False):
-    from django_cf.db.backends.d1.base import DatabaseWrapper
-
-    wrapper = DatabaseWrapper.__new__(DatabaseWrapper)
-    cursor_state = SimpleNamespace(_defer_foreign_keys=defer_foreign_keys)
-    wrapper.cursor = lambda: cursor_state
-    wrapper.binding = "DB"
-    wrapper.run_sync = lambda value: value
-    return wrapper
-
-
-def make_do_wrapper(defer_foreign_keys=False):
-    from django_cf.db.backends.do.base import DatabaseWrapper
-
-    wrapper = DatabaseWrapper.__new__(DatabaseWrapper)
-    cursor_state = SimpleNamespace(_defer_foreign_keys=defer_foreign_keys)
-    wrapper.cursor = lambda: cursor_state
-    return wrapper
-
-
-class FakeDOArray:
-    def __init__(self, data):
-        self.data = data
-
-    def toArray(self):
-        return self
-
-    def to_py(self):
-        return self.data
-
-
-class FakeDOStatement:
-    def __init__(self, data, *, rows_read=0, rows_written=0):
-        self.data = data
-        self.rowsRead = rows_read
-        self.rowsWritten = rows_written
-
-    def raw(self):
-        return FakeDOArray(self.data)
-
-
-class FakeDOStorage:
-    def __init__(self, statement=None, *, error=None):
-        self.statement = statement
-        self.error = error
-        self.calls = []
-
-    def exec(self, query, *params):
-        if self.error is not None:
-            raise self.error
-        self.calls.append((query, params))
-        return self.statement
+async def get_do_stub(env):
+    namespace = env.DO_STORAGE
+    object_id = namespace.idFromName("django-cf-backend-tests")
+    return namespace.get(object_id)
 
 
 class TestDODatabaseWrapperProcessQuery:
     def test_process_query_no_params(self):
-        wrapper = make_do_wrapper()
+        wrapper = DO_BACKEND
 
         result_query, result_params = wrapper.process_query(
             "SELECT * FROM users WHERE id = %s", None
@@ -73,7 +27,7 @@ class TestDODatabaseWrapperProcessQuery:
         assert result_params is None
 
     def test_process_query_with_params(self):
-        wrapper = make_do_wrapper()
+        wrapper = DO_BACKEND
 
         result_query, result_params = wrapper.process_query(
             "SELECT * FROM users WHERE id = %s AND name = %s", [1, "test"]
@@ -83,7 +37,7 @@ class TestDODatabaseWrapperProcessQuery:
         assert result_params == [1, "test"]
 
     def test_process_query_null_param_replaced_with_literal(self):
-        wrapper = make_do_wrapper()
+        wrapper = DO_BACKEND
 
         result_query, result_params = wrapper.process_query(
             "INSERT INTO users (name, email) VALUES (%s, %s)", ["test", None]
@@ -93,9 +47,14 @@ class TestDODatabaseWrapperProcessQuery:
         assert result_params == ["test"]
 
     def test_process_query_with_defer_foreign_keys(self):
-        result = make_do_wrapper(True).process_query(
-            "INSERT INTO users (name) VALUES (%s)", ["test"]
-        )
+        cursor = DO_BACKEND.cursor()
+        cursor.defer_foreign_keys(True)
+        try:
+            result = DO_BACKEND.process_query(
+                "INSERT INTO users (name) VALUES (%s)", ["test"]
+            )
+        finally:
+            cursor.defer_foreign_keys(False)
 
         assert "PRAGMA defer_foreign_keys = on" in result
         assert "PRAGMA defer_foreign_keys = off" in result
@@ -109,16 +68,16 @@ class TestDODatabaseWrapperConfiguration:
         assert DatabaseWrapper.display_name == "DO"
 
     def test_get_connection_params_returns_empty(self):
-        assert make_do_wrapper().get_connection_params() == {}
+        assert DO_BACKEND.get_connection_params() == {}
 
 
 class TestDOMissingDateTruncBug:
     def test_do_process_query_missing_date_trunc(self):
-        d1_result, _ = make_d1_wrapper().process_query(
+        d1_result, _ = D1_BACKEND.process_query(
             "SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders",
             ["year", "UTC", "UTC"],
         )
-        do_result, _ = make_do_wrapper().process_query(
+        do_result, _ = DO_BACKEND.process_query(
             "SELECT django_date_trunc(%s, created_at, %s, %s) FROM orders",
             ["year", "UTC", "UTC"],
         )
@@ -128,49 +87,34 @@ class TestDOMissingDateTruncBug:
 
 
 class TestDOStorageInitialization:
-    def test_storage_module_exists(self):
-        from django_cf.db.backends.do import storage
+    @pytest.mark.asyncio
+    async def test_storage_module_exists(self, env):
+        stub = await get_do_stub(env)
+        await stub.test_storage_is_configured()
 
-        storage.set_storage(None)
-        assert storage.get_storage() is None
-
-    def test_run_query_uses_configured_storage(self):
-        from django_cf.db.backends.do import storage
-
-        fake_storage = FakeDOStorage(FakeDOStatement([[1, "ok"]], rows_read=1))
-        storage.set_storage(fake_storage)
-
-        result = make_do_wrapper().run_query("SELECT * FROM test WHERE id = %s", [1])
-
-        assert list(result) == [(1, "ok")]
-        assert fake_storage.calls == [("SELECT * FROM test WHERE id = ?", (1,))]
+    @pytest.mark.asyncio
+    async def test_run_query_uses_configured_storage(self, env):
+        stub = await get_do_stub(env)
+        await stub.test_run_query_uses_configured_storage()
 
 
 class TestDOQueryExecution:
-    def test_read_query_uses_raw(self):
-        from django_cf.db.backends.do import storage
-
-        fake_storage = FakeDOStorage(FakeDOStatement([], rows_read=0, rows_written=0))
-        storage.set_storage(fake_storage)
-
-        result = make_do_wrapper().run_query("SELECT * FROM users")
-
-        assert result.fetchall() == []
+    @pytest.mark.asyncio
+    async def test_read_query_uses_raw(self, env):
+        stub = await get_do_stub(env)
+        await stub.test_read_query_uses_raw()
 
 
 class TestDOExceptionHandling:
-    def test_run_query_lets_binding_errors_propagate(self):
-        from django_cf.db.backends.do import storage
-
-        storage.set_storage(FakeDOStorage(error=RuntimeError("storage boom")))
-
-        with pytest.raises(RuntimeError, match="storage boom"):
-            make_do_wrapper().run_query("SELECT * FROM test")
+    @pytest.mark.asyncio
+    async def test_run_query_lets_binding_errors_propagate(self, env):
+        stub = await get_do_stub(env)
+        await stub.test_binding_errors_propagate()
 
 
 class TestDOParamConversion:
     def test_boolean_true_not_converted_in_process_query(self):
-        wrapper = make_do_wrapper()
+        wrapper = DO_BACKEND
 
         result_query, result_params = wrapper.process_query(
             "INSERT INTO test (active) VALUES (%s)", [True]
@@ -180,7 +124,7 @@ class TestDOParamConversion:
         assert result_params == [True]
 
     def test_multiple_none_params_order_preserved(self):
-        wrapper = make_do_wrapper()
+        wrapper = DO_BACKEND
 
         result_query, result_params = wrapper.process_query(
             "INSERT INTO test (a, b, c, d) VALUES (%s, %s, %s, %s)",
@@ -193,8 +137,13 @@ class TestDOParamConversion:
 
 class TestDOPragmaReturnTypeBug:
     def test_pragma_returns_string_not_tuple(self):
-        result = make_do_wrapper(True).process_query(
-            "INSERT INTO users (name) VALUES (%s)", ["test"]
-        )
+        cursor = DO_BACKEND.cursor()
+        cursor.defer_foreign_keys(True)
+        try:
+            result = DO_BACKEND.process_query(
+                "INSERT INTO users (name) VALUES (%s)", ["test"]
+            )
+        finally:
+            cursor.defer_foreign_keys(False)
 
         assert isinstance(result, str)

--- a/packages/django-cf/tests/in_worker/worker/src/test_storage_errors.py
+++ b/packages/django-cf/tests/in_worker/worker/src/test_storage_errors.py
@@ -234,14 +234,16 @@ class TestR2StorageListdirEdgeCases:
 class TestR2StorageTimeMethodsFallback:
     def test_get_accessed_time_returns_modified_time(self):
         storage = make_live_r2_storage(location=unique_name("r2-accessed-time"))
-        expected = datetime(2026, 1, 1, 12, 0, 0)
-        storage.get_modified_time = lambda name: expected
+        name = unique_name("accessed") + ".txt"
+        save_bytes(storage, name, b"content")
+        expected = storage.get_modified_time(name)
 
-        assert storage.get_accessed_time("file.txt") == expected
+        assert storage.get_accessed_time(name) == expected
 
     def test_get_created_time_returns_modified_time(self):
         storage = make_live_r2_storage(location=unique_name("r2-created-time"))
-        expected = datetime(2026, 1, 1, 12, 0, 0)
-        storage.get_modified_time = lambda name: expected
+        name = unique_name("created") + ".txt"
+        save_bytes(storage, name, b"content")
+        expected = storage.get_modified_time(name)
 
-        assert storage.get_created_time("file.txt") == expected
+        assert storage.get_created_time(name) == expected

--- a/packages/django-cf/tests/in_worker/worker/src/worker.py
+++ b/packages/django-cf/tests/in_worker/worker/src/worker.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import importlib.util
 import io
+import os
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -11,9 +12,21 @@ import django
 import django.conf
 import pytest
 from django.http import HttpResponse, JsonResponse
+from pyodide.webloop import WebLoop
+from worker_durable_object import TestDurableObject  # noqa: F401
 from workers import Response, WorkerEntrypoint
 
 BASE_DIR = Path(__file__).parent
+os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
+
+
+async def _noop(*args):
+    pass
+
+
+# pytest-asyncio relies on these methods, which older Pyodide WebLoops omit.
+WebLoop.shutdown_asyncgens = _noop
+WebLoop.shutdown_default_executor = _noop
 
 if not django.conf.settings.configured:
     django.conf.settings.configure(
@@ -34,7 +47,14 @@ if not django.conf.settings.configured:
             "default": {
                 "ENGINE": "django.db.backends.sqlite3",
                 "NAME": ":memory:",
-            }
+            },
+            "d1": {
+                "ENGINE": "django_cf.db.backends.d1",
+                "CLOUDFLARE_BINDING": "DB",
+            },
+            "do": {
+                "ENGINE": "django_cf.db.backends.do",
+            },
         },
         CACHES={
             "default": {

--- a/packages/django-cf/tests/in_worker/worker/src/worker_durable_object.py
+++ b/packages/django-cf/tests/in_worker/worker/src/worker_durable_object.py
@@ -1,9 +1,10 @@
 # pyright: reportMissingImports=false
 
 from django.db import connections
+from workers import DurableObject
+
 from django_cf import DjangoCFDurableObject
 from django_cf.db.backends.do.storage import get_storage
-from workers import DurableObject
 
 
 class TestDurableObject(DjangoCFDurableObject, DurableObject):

--- a/packages/django-cf/tests/in_worker/worker/src/worker_durable_object.py
+++ b/packages/django-cf/tests/in_worker/worker/src/worker_durable_object.py
@@ -1,0 +1,51 @@
+# pyright: reportMissingImports=false
+
+from django.db import connections
+from django_cf import DjangoCFDurableObject
+from django_cf.db.backends.do.storage import get_storage
+from workers import DurableObject
+
+
+class TestDurableObject(DjangoCFDurableObject, DurableObject):
+    @property
+    def database(self):
+        return connections["do"]
+
+    async def test_storage_is_configured(self):
+        assert get_storage() is not None
+
+    async def test_run_query_uses_configured_storage(self):
+        table = "_django_cf_do_configured_storage"
+        sql = self.ctx.storage.sql
+        sql.exec(f"DROP TABLE IF EXISTS {table}")
+        sql.exec(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY, value TEXT)")
+        sql.exec(f"INSERT INTO {table} VALUES (?, ?)", 1, "ok")
+
+        result = self.database.run_query(
+            f"SELECT id, value FROM {table} WHERE id = %s", [1]
+        )
+
+        assert list(result) == [(1, "ok")]
+        sql.exec(f"DROP TABLE {table}")
+
+    async def test_read_query_uses_raw(self):
+        table = "_django_cf_do_empty_read"
+        sql = self.ctx.storage.sql
+        sql.exec(f"DROP TABLE IF EXISTS {table}")
+        sql.exec(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY)")
+
+        result = self.database.run_query(f"SELECT * FROM {table}")
+
+        assert result.fetchall() == []
+        sql.exec(f"DROP TABLE {table}")
+
+    async def test_binding_errors_propagate(self):
+        table = "_django_cf_do_missing_table"
+        self.ctx.storage.sql.exec(f"DROP TABLE IF EXISTS {table}")
+
+        try:
+            self.database.run_query(f"SELECT * FROM {table}")
+        except Exception as exc:
+            assert "no such table" in str(exc).lower()
+        else:
+            raise AssertionError("expected the real Durable Object binding to raise")

--- a/packages/django-cf/tests/in_worker/worker/wrangler.jsonc
+++ b/packages/django-cf/tests/in_worker/worker/wrangler.jsonc
@@ -3,6 +3,27 @@
     "main": "src/worker.py",
     "compatibility_date": "%COMPAT_DATE",
     "compatibility_flags": ["python_workers"],
+    "d1_databases": [
+        {
+            "binding": "DB",
+            "database_name": "django-cf-in-worker-tests",
+            "database_id": "00000000-0000-0000-0000-000000000000"
+        }
+    ],
+    "durable_objects": {
+        "bindings": [
+            {
+                "name": "DO_STORAGE",
+                "class_name": "TestDurableObject"
+            }
+        ]
+    },
+    "migrations": [
+        {
+            "tag": "v1",
+            "new_sqlite_classes": ["TestDurableObject"]
+        }
+    ],
     "r2_buckets": [
         {
             "binding": "BUCKET",


### PR DESCRIPTION
Previously d1 and durable objects tests were using mock Python objects. This updates it to use a real local binding provided by wrangler, which makes the test more robust.