### PR TITLE
fix: fixes Request body being released too early

### DIFF
--- a/packages/runtime-sdk/src/workers/request.py
+++ b/packages/runtime-sdk/src/workers/request.py
@@ -9,6 +9,7 @@ from .blob import Blob
 from .formdata import FormData
 from .types import FetchKwargs
 from .utils import (
+    _get_js_body,
     _is_js_instance,
     _js_headers_to_http_message,
     _jsnull_to_none,
@@ -36,9 +37,14 @@ class Request:
 
         if "headers" in other_options:
             other_options["headers"] = _to_js_headers(other_options["headers"])
-        self._js_request = js.Request.new(
-            input._js_request if isinstance(input, Request) else input, **other_options
-        )
+        body = other_options.pop("body", None)
+        with _get_js_body(body) as js_body:
+            if body is not None:
+                other_options["body"] = js_body
+            self._js_request = js.Request.new(
+                input._js_request if isinstance(input, Request) else input,
+                **other_options,
+            )
 
     def __repr__(self):
         return (

--- a/packages/runtime-sdk/src/workers/response.py
+++ b/packages/runtime-sdk/src/workers/response.py
@@ -1,17 +1,17 @@
 import json
-from contextlib import contextmanager
 from http import HTTPStatus
 from typing import Any, Never
 
 import js
 import pyodide.http
-from pyodide.ffi import JsException, JsProxy, create_proxy
+from pyodide.ffi import JsException, JsProxy
 
 from .blob import Blob
 from .formdata import FormData
 from .types import Body, Headers
 from .utils import (
     RESPONSE_ACCEPTED_TYPES,
+    _get_js_body,
     _get_js_constructor_name,
     _is_js_instance,
     _js_headers_to_http_message,
@@ -19,23 +19,6 @@ from .utils import (
     _to_js_headers,
     _to_python_exception,
 )
-
-
-@contextmanager
-def _get_js_body(body):
-    if isinstance(body, bytes):
-        proxy_bytes = create_proxy(body)
-        proxy_buffer = proxy_bytes.getBuffer()
-        try:
-            yield proxy_buffer.data
-            return
-        finally:
-            proxy_buffer.release()
-            proxy_bytes.destroy()
-    if isinstance(body, FormData):
-        yield body.js_object
-        return
-    yield body
 
 
 class FetchResponse(pyodide.http.FetchResponse):

--- a/packages/runtime-sdk/src/workers/utils.py
+++ b/packages/runtime-sdk/src/workers/utils.py
@@ -6,6 +6,7 @@ import _pyodide_entrypoint_helper
 import js
 from pyodide.ffi import (
     JsException,
+    create_proxy,
     destroy_proxies,
     to_js,
 )
@@ -49,6 +50,25 @@ RESPONSE_ACCEPTED_TYPES = {
 _JS_PASSTHROUGH_TYPES = RESPONSE_ACCEPTED_TYPES | {
     "Headers",
 }
+
+
+@contextmanager
+def _get_js_body(body):
+    from .formdata import FormData
+
+    if isinstance(body, bytes):
+        proxy_bytes = create_proxy(body)
+        proxy_buffer = proxy_bytes.getBuffer()
+        try:
+            yield proxy_buffer.data
+            return
+        finally:
+            proxy_buffer.release()
+            proxy_bytes.destroy()
+    if isinstance(body, FormData):
+        yield body.js_object
+        return
+    yield body
 
 
 def _jsnull_to_none(x):

--- a/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/_client.py
+++ b/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/_client.py
@@ -46,6 +46,23 @@ async def post_json(app, path, data, **kwargs):
     )
 
 
+def build_multipart_bytes(files, boundary="----WebTestBoundary"):
+    """Build a binary-safe multipart body from (name, filename, bytes) tuples."""
+    body = bytearray()
+    for name, filename, content in files:
+        if isinstance(content, str):
+            content = content.encode()
+        body.extend(f"--{boundary}\r\n".encode())
+        body.extend(
+            f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'.encode()
+        )
+        body.extend(b"Content-Type: application/octet-stream\r\n\r\n")
+        body.extend(content)
+        body.extend(b"\r\n")
+    body.extend(f"--{boundary}--\r\n".encode())
+    return bytes(body), f"multipart/form-data; boundary={boundary}"
+
+
 def build_multipart(files, boundary="----WebTestBoundary"):
     """Build a multipart/form-data body from a list of (name, filename, content) tuples."""
     lines = []

--- a/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/test_platform_io.py
+++ b/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/test_platform_io.py
@@ -1,0 +1,31 @@
+"""Binary I/O tests across FastAPI, Pyodide, and workerd."""
+
+import hashlib
+
+import pytest
+from _client import build_multipart_bytes, fetch, read_json
+
+
+@pytest.mark.asyncio
+async def test_upload_spills_binary_file_to_virtual_disk(fastapi_app):
+    """UploadFile remains correct after SpooledTemporaryFile rolls to disk."""
+    payload = bytes(range(256)) * 5120  # 1.25 MiB, above Starlette's 1 MiB limit.
+    body, content_type = build_multipart_bytes(
+        [("file", "binary.dat", payload)], boundary="----SpoolBoundary"
+    )
+
+    resp = await fetch(
+        fastapi_app,
+        "/platform/upload-spooled",
+        method="POST",
+        headers={"Content-Type": content_type},
+        body=body,
+    )
+    assert resp.status == 200
+    data = await read_json(resp)
+    assert data == {
+        "size": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "reread_matches": True,
+        "rolled_to_disk": True,
+    }

--- a/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/worker.py
+++ b/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/worker.py
@@ -1,5 +1,6 @@
 import asyncio
 import enum
+import hashlib
 import importlib.util
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -434,6 +435,24 @@ app.include_router(v1_router)
 async def platform_lifespan_state(request: Request):
     resource = request.state.platform_resource
     return {"available": True, "closed": resource.closed}
+
+
+# --------------------------------------------------------------------------- #
+# Pyodide and Workers platform boundary routes
+# --------------------------------------------------------------------------- #
+
+
+@app.post("/platform/upload-spooled")
+async def platform_upload_spooled(file: UploadFile = File(...)):  # noqa: B008
+    first = await file.read()
+    await file.seek(0)
+    second = await file.read()
+    return {
+        "size": len(first),
+        "sha256": hashlib.sha256(first).hexdigest(),
+        "reread_matches": first == second,
+        "rolled_to_disk": bool(getattr(file.file, "_rolled", False)),
+    }
 
 
 @app.get("/native-file")

--- a/packages/runtime-sdk/tests/workerd-test/sdk/tests/test_sdk.py
+++ b/packages/runtime-sdk/tests/workerd-test/sdk/tests/test_sdk.py
@@ -436,6 +436,11 @@ async def test_request_unit_tests():
     blob = await req_for_blob.blob()
     assert (await blob.text()) == "foobar"
 
+    # Verify that Python bytes are converted without UTF-8 decoding or truncation.
+    binary_body = bytes(range(256))
+    req_for_bytes = Request("http://example.com", body=binary_body, method="POST")
+    assert await req_for_bytes.bytes() == binary_body
+
     # Verify that we can get a FormData back.
     js_form_data = js.FormData.new()
     js_form_data.append("foobar", 123)


### PR DESCRIPTION
It looks like we need to use create_proxy here to ensure the body isn't freed too early.

### Test Plan

```
cd packages/runtime-sdk
uv run pytest 'tests/test_fastapi.py::TestPLATFORM_IO::test_upload_spills_binary_file_to_virtual_disk[3.13]' -v
uv run pytest 'tests/test_in_workerd.py::test_in_workerd[sdk-3.13]' -v
```