### PR TITLE
fix: fixes fastapi lifespan state not persisting

### DIFF
--- a/packages/runtime-sdk/src/workers/asgi.py
+++ b/packages/runtime-sdk/src/workers/asgi.py
@@ -49,7 +49,7 @@ def acquire_js_buffer(pybuffer):
         buf.release()
 
 
-def request_to_scope(req, env, ws=False):
+def request_to_scope(req, env, ws=False, state=None):
     from js import URL
 
     # @app.get("/example")
@@ -74,7 +74,7 @@ def request_to_scope(req, env, ws=False):
         ty = "websocket"
     else:
         ty = "http"
-    return {
+    scope = {
         "asgi": ASGI,
         "headers": headers,
         "http_version": "1.1",
@@ -86,6 +86,10 @@ def request_to_scope(req, env, ws=False):
         "type": ty,
         "env": env,
     }
+    if state is not None:
+        # ASGI requires a shallow copy of lifespan state for each request.
+        scope["state"] = dict(state)
+    return scope
 
 
 async def start_application(app):
@@ -94,6 +98,7 @@ async def start_application(app):
     # don't implement it and fall back to serving requests without lifespan.
     # https://asgi.readthedocs.io/en/latest/specs/lifespan.html
     receive_queue = Queue()
+    state = {}
     await receive_queue.put({"type": "lifespan.startup"})
 
     # `startup` resolves True on `lifespan.startup.complete`, False when the app
@@ -141,7 +146,7 @@ async def start_application(app):
             await app(
                 {
                     "asgi": ASGI,
-                    "state": {},
+                    "state": state,
                     "type": "lifespan",
                 },
                 receive,
@@ -168,17 +173,18 @@ async def start_application(app):
     run_in_background(run_lifespan())
     supported = await startup
     if not supported:
-        return no_lifespan_shutdown
-    return shutdown
+        return no_lifespan_shutdown, state
+    return shutdown, state
 
 
-async def process_request(
+async def process_request(  # noqa: PLR0913
     app: Any,
     req: "Request | js.Request",
     env: Any,
     # added for waitUntil, but not used anymore
     # TODO(later): remove this parameter after unvendoring Python SDK from workerd
     ctx: Context | None,
+    state: dict[str, Any] | None = None,
 ) -> js.Response:
     from js import Response, TransformStream
     from pyodide.ffi import create_proxy
@@ -273,7 +279,7 @@ async def process_request(
     # Run the application in the background
     async def run_app():
         try:
-            await app(request_to_scope(req, env), receive, send)
+            await app(request_to_scope(req, env, state=state), receive, send)
 
             # If we get here and no response has been set yet, the app didn't generate a response
             if not result.done():
@@ -380,9 +386,9 @@ async def fetch(
     app: Any, req: "Request | js.Request", env: Any, ctx: Context | None = None
 ) -> js.Response:
     logger.debug("ASGI request: %s %s", req.method, req.url)
-    shutdown = await start_application(app)
+    shutdown, state = await start_application(app)
     try:
-        result = await process_request(app, req, env, ctx)
+        result = await process_request(app, req, env, ctx, state=state)
     except Exception:
         logger.exception("ASGI request failed")
         raise

--- a/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/test_platform_lifecycle.py
+++ b/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/test_platform_lifecycle.py
@@ -1,0 +1,12 @@
+"""FastAPI lifespan state tests targeting the Workers ASGI boundary."""
+
+import pytest
+from _client import get_json
+
+
+@pytest.mark.asyncio
+async def test_lifespan_state_reaches_request(fastapi_app):
+    """State yielded by FastAPI's lifespan context is copied to HTTP scopes."""
+    resp, data = await get_json(fastapi_app, "/platform/lifespan-state")
+    assert resp.status == 200
+    assert data == {"available": True, "closed": False}

--- a/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/worker.py
+++ b/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/worker.py
@@ -1,6 +1,7 @@
 import asyncio
 import enum
 import importlib.util
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
@@ -43,7 +44,22 @@ WebLoop.shutdown_default_executor = _noop
 
 STATIC_DIR = Path(__file__).parent / "static"
 
-app = FastAPI()
+
+class PlatformResource:
+    def __init__(self):
+        self.closed = False
+
+
+@asynccontextmanager
+async def _platform_lifespan(_app):
+    resource = PlatformResource()
+    try:
+        yield {"platform_resource": resource}
+    finally:
+        resource.closed = True
+
+
+app = FastAPI(lifespan=_platform_lifespan)
 
 # --------------------------------------------------------------------------- #
 # Shared mutable state used to verify side-effects (e.g. background tasks).
@@ -412,6 +428,12 @@ async def v1_info():
 
 
 app.include_router(v1_router)
+
+
+@app.get("/platform/lifespan-state")
+async def platform_lifespan_state(request: Request):
+    resource = request.state.platform_resource
+    return {"available": True, "closed": resource.closed}
 
 
 @app.get("/native-file")


### PR DESCRIPTION
Resolves issue with lifespan events https://fastapi.tiangolo.com/advanced/events/#lifespan

### Test Plan

```
$ uv run pytest 'tests/test_fastapi.py::TestPLATFORM_LIFECYCLE::test_lifespan_state_reaches_request[3.13]' -v
```