### PR TITLE
chore: fastapi tests for multi set-cookie and other boundaries

### DIFF
--- a/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/_client.py
+++ b/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/_client.py
@@ -1,5 +1,8 @@
 import json as _json
 
+import js
+from pyodide.ffi import create_proxy, to_js
+
 import asgi
 from workers import Request
 
@@ -61,6 +64,35 @@ def build_multipart_bytes(files, boundary="----WebTestBoundary"):
         body.extend(b"\r\n")
     body.extend(f"--{boundary}--\r\n".encode())
     return bytes(body), f"multipart/form-data; boundary={boundary}"
+
+
+async def fetch_chunks(app, path, chunks, env=None, method="POST", headers=None):
+    """Send a request body as a JS ReadableStream with explicit chunk boundaries."""
+    from js import Object
+
+    chunks = list(chunks)
+
+    def start(controller):
+        for chunk in chunks:
+            controller.enqueue(to_js(chunk))
+        controller.close()
+
+    start_proxy = create_proxy(start)
+    try:
+        stream = js.ReadableStream.new(
+            to_js({"start": start_proxy}, dict_converter=Object.fromEntries)
+        )
+        hdrs = dict(headers or {})
+        hdrs.setdefault("Content-Length", str(sum(len(chunk) for chunk in chunks)))
+        request = Request(
+            f"{BASE_URL}{path}",
+            method=method,
+            headers=hdrs,
+            body=stream,
+        )
+        return await asgi.fetch(app, request, env or {})
+    finally:
+        start_proxy.destroy()
 
 
 def build_multipart(files, boundary="----WebTestBoundary"):

--- a/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/test_platform_boundaries.py
+++ b/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/test_platform_boundaries.py
@@ -1,0 +1,99 @@
+"""Tests across the FastAPI, Pyodide, and Workers runtime boundaries."""
+
+import asyncio
+import gzip
+import hashlib
+import json
+
+import pytest
+from _client import fetch, fetch_chunks, read_json
+from worker import reset_platform_concurrency
+
+
+@pytest.mark.asyncio
+async def test_chunked_js_stream_preserves_utf8_and_boundaries(fastapi_app):
+    """A JS ReadableStream survives the JS-to-Python ASGI receive bridge."""
+    value = {
+        "message": "worker \u0063\u0061\u0066\u00e9 \U0001f680",
+        "items": [1, 2, 3],
+    }
+    body = json.dumps(value, ensure_ascii=False).encode()
+    emoji = "\U0001f680".encode()
+    emoji_start = body.index(emoji)
+    cuts = [7, emoji_start + 1, emoji_start + 3, len(body) - 2]
+    chunks = []
+    start = 0
+    for end in cuts + [len(body)]:
+        chunks.append(body[start:end])
+        start = end
+
+    resp = await fetch_chunks(
+        fastapi_app,
+        "/platform/chunked-json",
+        chunks,
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status == 200
+    data = await read_json(resp)
+    assert data["chunk_sizes"] == [len(chunk) for chunk in chunks]
+    assert data["sha256"] == hashlib.sha256(body).hexdigest()
+    assert data["data"] == value
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_keep_bindings_and_data_isolated(fastapi_app):
+    """Interleaved requests retain their own env, headers, and bodies."""
+    reset_platform_concurrency()
+
+    async def request(marker):
+        resp = await fetch(
+            fastapi_app,
+            "/platform/concurrent-env",
+            env={"marker": marker},
+            method="POST",
+            headers={"X-Request-Marker": marker},
+            body=f"body-{marker}",
+        )
+        assert resp.status == 200
+        return await read_json(resp)
+
+    first, second = await asyncio.wait_for(
+        asyncio.gather(request("first"), request("second")), timeout=5
+    )
+    assert first == {
+        "binding": "first",
+        "header": "first",
+        "body": "body-first",
+    }
+    assert second == {
+        "binding": "second",
+        "header": "second",
+        "body": "body-second",
+    }
+
+
+@pytest.mark.asyncio
+async def test_multiple_set_cookie_headers_survive_fastapi(fastapi_app):
+    """FastAPI's separate Set-Cookie headers remain distinct through JS Headers."""
+    resp = await fetch(fastapi_app, "/platform/multiple-cookies")
+    assert resp.status == 200
+    cookies = list(resp.headers.getSetCookie())
+    assert len(cookies) == 3
+    assert cookies[0].startswith("first=1;")
+    assert cookies[1].startswith("second=two;")
+    assert cookies[2].startswith("dated=3;")
+    assert "Wed, 21 Oct 2037 07:28:00 GMT" in cookies[2]
+
+
+@pytest.mark.asyncio
+async def test_gzip_middleware_preserves_binary_body(fastapi_app):
+    """GZipMiddleware compresses binary data streamed through a JS Response."""
+    expected = bytes(range(256)) * 32
+    resp = await fetch(
+        fastapi_app,
+        "/platform/gzip-binary",
+        headers={"Accept-Encoding": "gzip"},
+    )
+    assert resp.status == 200
+    assert resp.headers.get("content-encoding") == "gzip"
+    assert gzip.decompress((await resp.bytes()).to_bytes()) == expected

--- a/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/worker.py
+++ b/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/worker.py
@@ -2,6 +2,7 @@ import asyncio
 import enum
 import hashlib
 import importlib.util
+import json
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -32,6 +33,7 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from pyodide.webloop import WebLoop
 from starlette.background import BackgroundTask
+from starlette.middleware.gzip import GZipMiddleware
 
 import asgi
 
@@ -61,6 +63,18 @@ async def _platform_lifespan(_app):
 
 
 app = FastAPI(lifespan=_platform_lifespan)
+app.add_middleware(GZipMiddleware, minimum_size=1024)
+
+_platform_concurrency_ready = asyncio.Event()
+_platform_concurrency_count = 0
+
+
+def reset_platform_concurrency():
+    global _platform_concurrency_count
+
+    _platform_concurrency_count = 0
+    _platform_concurrency_ready.clear()
+
 
 # --------------------------------------------------------------------------- #
 # Shared mutable state used to verify side-effects (e.g. background tasks).
@@ -461,6 +475,53 @@ async def platform_upload_spooled(file: UploadFile = File(...)):  # noqa: B008
         "reread_matches": first == second,
         "rolled_to_disk": bool(getattr(file.file, "_rolled", False)),
     }
+
+
+@app.post("/platform/chunked-json")
+async def platform_chunked_json(request: Request):
+    chunks = [chunk async for chunk in request.stream() if chunk]
+    body = b"".join(chunks)
+    return {
+        "chunk_sizes": [len(chunk) for chunk in chunks],
+        "sha256": hashlib.sha256(body).hexdigest(),
+        "data": json.loads(body),
+    }
+
+
+@app.post("/platform/concurrent-env")
+async def platform_concurrent_env(
+    request: Request,
+    bindings=asgi.env,  # noqa: B008
+):
+    global _platform_concurrency_count
+
+    _platform_concurrency_count += 1
+    if _platform_concurrency_count == 2:
+        _platform_concurrency_ready.set()
+    await asyncio.wait_for(_platform_concurrency_ready.wait(), timeout=5)
+    body = await request.body()
+    return {
+        "binding": bindings["marker"],
+        "header": request.headers["x-request-marker"],
+        "body": body.decode(),
+    }
+
+
+@app.get("/platform/multiple-cookies")
+async def platform_multiple_cookies():
+    response = JSONResponse({"ok": True})
+    response.set_cookie("first", "1")
+    response.set_cookie("second", "two")
+    response.set_cookie("dated", "3", expires="Wed, 21 Oct 2037 07:28:00 GMT")
+    return response
+
+
+@app.get("/platform/gzip-binary")
+async def platform_gzip_binary():
+    return FastAPIResponse(
+        content=(bytes(range(256)) * 32),
+        media_type="application/octet-stream",
+    )
 
 
 @app.get("/native-file")


### PR DESCRIPTION
Adds 4 fastapi tests:

- Chunked UTF-8 stream boundaries
- Concurrent request/environment isolation
- Multiple Set-Cookie headers
- Binary GZip responses

### Test Plan

```
uv run pytest 'tests/test_fastapi.py::TestPLATFORM_BOUNDARIES' -v
```