### PR TITLE
fix(cli): remove enable date from Python 3.14

### DIFF
--- a/packages/cli/src/pywrangler/metadata.py
+++ b/packages/cli/src/pywrangler/metadata.py
@@ -10,7 +10,7 @@ class PythonCompatVersion(NamedTuple):
 
 
 PYTHON_COMPAT_VERSIONS = [
-    PythonCompatVersion("3.14", "python_workers_20260610", None, experimental=True),
+    PythonCompatVersion("3.14", "python_workers_20260610", None),
     PythonCompatVersion(
         "3.13", "python_workers_20250116", datetime.strptime("2025-09-29", "%Y-%m-%d")
     ),

--- a/packages/cli/src/pywrangler/metadata.py
+++ b/packages/cli/src/pywrangler/metadata.py
@@ -10,9 +10,7 @@ class PythonCompatVersion(NamedTuple):
 
 
 PYTHON_COMPAT_VERSIONS = [
-    PythonCompatVersion(
-        "3.14", "python_workers_20260610", datetime.strptime("2026-08-25", "%Y-%m-%d")
-    ),
+    PythonCompatVersion("3.14", "python_workers_20260610", None, experimental=True),
     PythonCompatVersion(
         "3.13", "python_workers_20250116", datetime.strptime("2025-09-29", "%Y-%m-%d")
     ),

--- a/packages/cli/tests/test_cli.py
+++ b/packages/cli/tests/test_cli.py
@@ -747,7 +747,7 @@ def test_proxy_to_wrangler_handles_subprocess_error(mock_subprocess_run):
     }
 
 
-@pytest.mark.xfail(reason="reenable when 3.14 gets enable date")
+@pytest.mark.xfail(reason="re-enable when 3.14 gets enable date")
 def test_sync_command_finds_pyproject_in_parent_directory(test_dir):
     """Test that the sync command can find pyproject.toml in a parent directory."""
     # Create pyproject.toml in the test directory (parent)

--- a/packages/cli/tests/test_cli.py
+++ b/packages/cli/tests/test_cli.py
@@ -91,7 +91,7 @@ def _wrangler_compat_config(python_version: str) -> tuple[str, str]:
     if python_version == "3.13":
         compat_flags.append("python_workers_20250116")
     if python_version == "3.14":
-        compat_flags.append("python_workers_20260610, experimental")
+        compat_flags.append("python_workers_20260610")
 
     compat_flags_str = ", ".join([f'"{flag}"' for flag in compat_flags])
 
@@ -747,6 +747,7 @@ def test_proxy_to_wrangler_handles_subprocess_error(mock_subprocess_run):
     }
 
 
+@pytest.mark.xfail(reason="reenable when 3.14 gets enable date")
 def test_sync_command_finds_pyproject_in_parent_directory(test_dir):
     """Test that the sync command can find pyproject.toml in a parent directory."""
     # Create pyproject.toml in the test directory (parent)

--- a/packages/cli/tests/test_cli.py
+++ b/packages/cli/tests/test_cli.py
@@ -91,7 +91,7 @@ def _wrangler_compat_config(python_version: str) -> tuple[str, str]:
     if python_version == "3.13":
         compat_flags.append("python_workers_20250116")
     if python_version == "3.14":
-        compat_flags.append("python_workers_20260610")
+        compat_flags.append("python_workers_20260610, experimental")
 
     compat_flags_str = ", ".join([f'"{flag}"' for flag in compat_flags])
 


### PR DESCRIPTION
reverts #197

marking it experimental again so we can bump Pyodide version and compat flag again.