### PR TITLE
test(django-cf): add more tests using django ORM

### DIFF
--- a/packages/django-cf/tests/in_worker/worker/src/_django_app.py
+++ b/packages/django-cf/tests/in_worker/worker/src/_django_app.py
@@ -1,0 +1,12 @@
+# pyright: reportMissingImports=false
+
+import functools
+
+R2_LOCATION = "in-worker-media"
+
+
+@functools.cache
+def django_wsgi_app():
+    from django.core.wsgi import get_wsgi_application
+
+    return get_wsgi_application()

--- a/packages/django-cf/tests/in_worker/worker/src/_do_orm_app.py
+++ b/packages/django-cf/tests/in_worker/worker/src/_do_orm_app.py
@@ -1,0 +1,87 @@
+# pyright: reportMissingImports=false
+
+from django.db import models
+from django.http import JsonResponse
+from django.urls import path
+
+DO_ALIAS = "do"
+DO_TABLE = "_django_cf_do_orm_records"
+CREATE_DO_TABLE_SQL = (
+    f"CREATE TABLE {DO_TABLE} ("
+    "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+    "value TEXT NOT NULL, "
+    "weight INTEGER NOT NULL)"
+)
+DROP_DO_TABLE_SQL = f"DROP TABLE IF EXISTS {DO_TABLE}"
+
+
+class DoOrmRecord(models.Model):
+    value = models.CharField(max_length=64)
+    weight = models.IntegerField()
+
+    class Meta:
+        app_label = "django_cf_in_worker"
+        db_table = DO_TABLE
+        managed = False
+
+
+def _records():
+    return DoOrmRecord.objects.using(DO_ALIAS)
+
+
+def do_orm_crud_view(request):
+    del request
+    created = _records().create(value="alpha", weight=3)
+    _records().create(value="bravo", weight=1)
+    _records().create(value="charlie", weight=2)
+
+    loaded = _records().get(pk=created.pk)
+    loaded.value = "alpha-updated"
+    loaded.save(using=DO_ALIAS, update_fields=["value"])
+
+    deleted, _ = _records().filter(value="bravo").delete()
+
+    return JsonResponse(
+        {
+            "created_id": created.pk,
+            "updated_value": _records().get(pk=created.pk).value,
+            "deleted": deleted,
+            "remaining": list(
+                _records().order_by("value").values_list("value", flat=True)
+            ),
+        }
+    )
+
+
+def do_orm_query_view(request):
+    del request
+    for value, weight in (("one", 1), ("two", 2), ("three", 3)):
+        _records().create(value=value, weight=weight)
+
+    ascending = list(_records().order_by("weight").values_list("value", flat=True))
+    descending = list(_records().order_by("-weight").values_list("value", flat=True))
+    excluded = list(
+        _records().exclude(weight=2).order_by("weight").values_list("value", flat=True)
+    )
+    matching = _records().filter(value="two").exists()
+    missing = _records().filter(value="four").exists()
+    deleted, _ = _records().all().delete()
+
+    return JsonResponse(
+        {
+            "count": len(ascending),
+            "matching": matching,
+            "missing": missing,
+            "ascending": ascending,
+            "descending": descending,
+            "excluded": excluded,
+            "deleted": deleted,
+            "remaining": _records().count(),
+        }
+    )
+
+
+urlpatterns = [
+    path("do/orm/crud/", do_orm_crud_view),
+    path("do/orm/query/", do_orm_query_view),
+]

--- a/packages/django-cf/tests/in_worker/worker/src/_r2_document_app.py
+++ b/packages/django-cf/tests/in_worker/worker/src/_r2_document_app.py
@@ -1,0 +1,85 @@
+# pyright: reportMissingImports=false
+
+from uuid import uuid4
+
+from django.core.files.base import ContentFile
+from django.db import connections, models
+from django.http import JsonResponse
+
+D1_ALIAS = "d1"
+R2_TABLE = "_django_cf_r2_documents"
+R2_UPLOAD_TO = "r2-documents"
+R2_CONTENT = b"r2-document-content"
+CREATE_R2_TABLE_SQL = (
+    f"CREATE TABLE {R2_TABLE} "
+    "(id INTEGER PRIMARY KEY AUTOINCREMENT, attachment TEXT NOT NULL)"
+)
+DROP_R2_TABLE_SQL = f"DROP TABLE IF EXISTS {R2_TABLE}"
+
+
+class R2Document(models.Model):
+    attachment = models.FileField(upload_to=R2_UPLOAD_TO, max_length=200)
+
+    class Meta:
+        app_label = "django_cf_in_worker"
+        db_table = R2_TABLE
+        managed = False
+
+
+def drop_r2_table():
+    connections[D1_ALIAS].run_query(DROP_R2_TABLE_SQL)
+
+
+def create_r2_table():
+    drop_r2_table()
+    connections[D1_ALIAS].run_query(CREATE_R2_TABLE_SQL)
+
+
+def document_lifecycle_payload():
+    documents = R2Document.objects.using(D1_ALIAS)
+    document = R2Document()
+    document.attachment.save(
+        f"payload-{uuid4().hex}.bin", ContentFile(R2_CONTENT), save=False
+    )
+    name = document.attachment.name
+    storage = document.attachment.storage
+
+    try:
+        document.save(using=D1_ALIAS)
+        loaded = documents.get(pk=document.pk)
+        attachment = loaded.attachment
+        attachment.open("rb")
+        try:
+            content = attachment.read()
+        finally:
+            attachment.close()
+
+        payload = {
+            "id": loaded.pk,
+            "name": name,
+            "content": content.decode(),
+            "size": attachment.size,
+            "url": attachment.url,
+            "exists_before_delete": storage.exists(name),
+        }
+
+        attachment.delete(save=False)
+        payload["exists_after_delete"] = storage.exists(name)
+        loaded.delete(using=D1_ALIAS)
+        payload["rows_after_delete"] = documents.count()
+        return payload
+    finally:
+        if storage.exists(name):
+            storage.delete(name)
+        if document.pk is not None:
+            documents.filter(pk=document.pk).delete()
+
+
+def sync_document_view(request):
+    del request
+    return JsonResponse(document_lifecycle_payload())
+
+
+async def async_document_view(request):
+    del request
+    return JsonResponse(document_lifecycle_payload())

--- a/packages/django-cf/tests/in_worker/worker/src/_wsgi_client.py
+++ b/packages/django-cf/tests/in_worker/worker/src/_wsgi_client.py
@@ -1,0 +1,25 @@
+# pyright: reportMissingImports=false
+
+import json as _json
+
+from _django_app import django_wsgi_app
+from workers import Request
+
+from django_cf import handle_wsgi
+
+BASE_URL = "http://testserver"
+
+
+async def fetch(path, *, env=None):
+    request = Request(f"{BASE_URL}{path}")
+    return await handle_wsgi(request, django_wsgi_app(), {} if env is None else env)
+
+
+async def read_json(response):
+    text = await response.text()
+    return _json.loads(text) if text else None
+
+
+async def get_json(path, **kwargs):
+    response = await fetch(path, **kwargs)
+    return response, await read_json(response)

--- a/packages/django-cf/tests/in_worker/worker/src/test_asgi_do.py
+++ b/packages/django-cf/tests/in_worker/worker/src/test_asgi_do.py
@@ -1,0 +1,59 @@
+"""Durable Objects WSGI ORM tests executed inside workerd.
+
+``stub.fetch`` reaches ``DjangoCFDurableObject.fetch``, which hands the request
+to ``django_cf.handle_wsgi``, so these are WSGI requests served by
+``TestDurableObject`` with the synchronous ORM running against the Durable
+Object storage the object configures in its constructor.
+"""
+
+# pyright: reportMissingImports=false
+
+import pytest
+from _wsgi_client import read_json
+
+DO_BASE_URL = "http://django-cf-do"
+
+
+async def get_do_stub(env):
+    namespace = env.DO_STORAGE
+    object_id = namespace.idFromName("django-cf-backend-tests")
+    return namespace.get(object_id)
+
+
+async def _run_do_request(env, path_name):
+    stub = await get_do_stub(env)
+    await stub.create_orm_table()
+    try:
+        response = await stub.fetch(f"{DO_BASE_URL}{path_name}")
+        return response, await read_json(response)
+    finally:
+        await stub.drop_orm_table()
+
+
+@pytest.mark.asyncio
+async def test_do_orm_wsgi_crud_lifecycle_through_django_url(env):
+    response, payload = await _run_do_request(env, "/do/orm/crud/")
+
+    assert response.status == 200
+    assert payload is not None
+    assert isinstance(payload["created_id"], int)
+    assert payload["created_id"] > 0
+    assert payload["updated_value"] == "alpha-updated"
+    assert payload["deleted"] == 1
+    assert payload["remaining"] == ["alpha-updated", "charlie"]
+
+
+@pytest.mark.asyncio
+async def test_do_orm_wsgi_filter_order_and_delete_through_django_url(env):
+    response, payload = await _run_do_request(env, "/do/orm/query/")
+
+    assert response.status == 200
+    assert payload is not None
+    assert payload["count"] == 3
+    assert payload["matching"] is True
+    assert payload["missing"] is False
+    assert payload["ascending"] == ["one", "two", "three"]
+    assert payload["descending"] == ["three", "two", "one"]
+    assert payload["excluded"] == ["one", "three"]
+    assert payload["deleted"] == 3
+    assert payload["remaining"] == 0

--- a/packages/django-cf/tests/in_worker/worker/src/test_wsgi_d1.py
+++ b/packages/django-cf/tests/in_worker/worker/src/test_wsgi_d1.py
@@ -1,0 +1,99 @@
+"""WSGI D1 tests executed inside workerd.
+
+Requests are driven through ``django_cf.handle_wsgi`` and the shared cached WSGI
+app, so the synchronous ORM path is exercised end to end. ``test_asgi_d1``
+covers the asynchronous equivalent.
+"""
+
+# pyright: reportMissingImports=false
+
+import pytest
+from _wsgi_client import get_json
+from django.db import connections, models
+from django.http import JsonResponse
+from django.test import override_settings
+from django.urls import path
+
+D1_ALIAS = "d1"
+D1_TABLE = "_django_cf_wsgi_d1_records"
+
+
+class WsgiD1Record(models.Model):
+    value = models.CharField(max_length=64)
+
+    class Meta:
+        app_label = "django_cf_in_worker"
+        db_table = D1_TABLE
+        managed = False
+
+
+def crud_view(request):
+    del request
+    records = WsgiD1Record.objects.using(D1_ALIAS)
+
+    created = records.create(value="lifecycle-created")
+    records.create(value="lifecycle-other")
+    records.create(value="lifecycle-zulu")
+
+    created.value = "lifecycle-updated"
+    created.save(using=D1_ALIAS, update_fields=["value"])
+
+    loaded = records.get(pk=created.pk)
+    filtered = sorted(
+        records.filter(value__startswith="lifecycle-").values_list("value", flat=True)
+    )
+    deleted, _ = records.filter(pk=created.pk).delete()
+
+    return JsonResponse(
+        {
+            "id": loaded.pk,
+            "value": loaded.value,
+            "filtered": filtered,
+            "deleted": deleted,
+            "remaining": list(
+                records.order_by("value").values_list("value", flat=True)
+            ),
+        }
+    )
+
+
+urlpatterns = [path("wsgi/d1/crud/", crud_view)]
+
+
+def _drop_d1_table():
+    connections[D1_ALIAS].run_query(f"DROP TABLE IF EXISTS {D1_TABLE}")
+
+
+def _create_d1_table():
+    _drop_d1_table()
+    connections[D1_ALIAS].run_query(
+        f"CREATE TABLE {D1_TABLE} "
+        "(id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL)"
+    )
+
+
+async def _run_d1_request(path_name):
+    _create_d1_table()
+    try:
+        with override_settings(ROOT_URLCONF=__name__):
+            return await get_json(path_name)
+    finally:
+        _drop_d1_table()
+
+
+@pytest.mark.asyncio
+async def test_wsgi_d1_orm_crud_lifecycle():
+    response, payload = await _run_d1_request("/wsgi/d1/crud/")
+
+    assert response.status == 200
+    assert payload is not None
+    assert isinstance(payload["id"], int)
+    assert payload["id"] > 0
+    assert payload["value"] == "lifecycle-updated"
+    assert payload["filtered"] == [
+        "lifecycle-other",
+        "lifecycle-updated",
+        "lifecycle-zulu",
+    ]
+    assert payload["deleted"] == 1
+    assert payload["remaining"] == ["lifecycle-other", "lifecycle-zulu"]

--- a/packages/django-cf/tests/in_worker/worker/src/test_wsgi_r2.py
+++ b/packages/django-cf/tests/in_worker/worker/src/test_wsgi_r2.py
@@ -1,41 +1,40 @@
-"""ASGI R2 tests executed inside workerd.
+"""WSGI R2 tests executed inside workerd.
 
-The view goes through the configured ``STORAGES["default"]`` backend and a model
-``FileField`` instead of instantiating ``R2Storage`` directly. ``test_wsgi_r2``
-drives the same lifecycle through the WSGI adapter.
+Requests are driven through ``django_cf.handle_wsgi`` and the shared cached WSGI
+app, so the same ``STORAGES["default"]`` / ``FileField`` lifecycle that
+``test_asgi_r2`` covers is also exercised over the WSGI adapter.
 """
 
 # pyright: reportMissingImports=false
 
 import pytest
-from _asgi_client import get_json
 from _django_app import R2_LOCATION
 from _r2_document_app import (
     R2_CONTENT,
     R2_UPLOAD_TO,
-    async_document_view,
     create_r2_table,
     drop_r2_table,
+    sync_document_view,
 )
-from django.core.handlers.asgi import ASGIHandler
+from _wsgi_client import get_json
 from django.test import override_settings
 from django.urls import path
 
-urlpatterns = [path("asgi/r2/document/", async_document_view)]
+urlpatterns = [path("wsgi/r2/document/", sync_document_view)]
 
 
 async def _run_r2_request(path_name):
     create_r2_table()
     try:
         with override_settings(ROOT_URLCONF=__name__):
-            return await get_json(ASGIHandler(), path_name)
+            return await get_json(path_name)
     finally:
         drop_r2_table()
 
 
 @pytest.mark.asyncio
-async def test_asgi_r2_filefield_save_read_and_delete():
-    response, payload = await _run_r2_request("/asgi/r2/document/")
+async def test_wsgi_r2_filefield_save_read_and_delete():
+    response, payload = await _run_r2_request("/wsgi/r2/document/")
 
     assert response.status == 200
     assert payload is not None

--- a/packages/django-cf/tests/in_worker/worker/src/worker.py
+++ b/packages/django-cf/tests/in_worker/worker/src/worker.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import contextlib
-import functools
 import importlib.util
 import io
 import os
@@ -12,6 +11,7 @@ from urllib.parse import urlparse
 import django
 import django.conf
 import pytest
+from _django_app import R2_LOCATION, django_wsgi_app
 from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from django.urls import path
 from pyodide.webloop import WebLoop
@@ -64,6 +64,19 @@ if not django.conf.settings.configured:
             }
         },
         SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies",
+        MEDIA_URL="/media/",
+        STORAGES={
+            "default": {
+                "BACKEND": "django_cf.storage.R2Storage",
+                "OPTIONS": {
+                    "binding": "BUCKET",
+                    "location": R2_LOCATION,
+                },
+            },
+            "staticfiles": {
+                "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+            },
+        },
         USE_TZ=True,
         TIME_ZONE="UTC",
         DEFAULT_AUTO_FIELD="django.db.models.AutoField",
@@ -71,14 +84,9 @@ if not django.conf.settings.configured:
 
 django.setup()
 
+from _do_orm_app import urlpatterns as do_orm_urlpatterns  # noqa: E402
+
 from django_cf import DjangoCF  # noqa: E402
-
-
-@functools.cache
-def _django_wsgi_app():
-    from django.core.wsgi import get_wsgi_application
-
-    return get_wsgi_application()
 
 
 def _django_binary_view(request):
@@ -137,6 +145,7 @@ urlpatterns = [
     path("django/meta/<str:segment>/", _django_meta_view),
     path("django/body/", _django_body_view),
     path("django/headers/", _django_headers_view),
+    *do_orm_urlpatterns,
 ]
 
 
@@ -206,7 +215,7 @@ class EnvPlugin:
 
 class Default(DjangoCF, WorkerEntrypoint):
     def get_app(self):
-        return _django_wsgi_app()
+        return django_wsgi_app()
 
     async def fetch(self, request):
         path = urlparse(request.url).path

--- a/packages/django-cf/tests/in_worker/worker/src/worker_durable_object.py
+++ b/packages/django-cf/tests/in_worker/worker/src/worker_durable_object.py
@@ -1,5 +1,6 @@
 # pyright: reportMissingImports=false
 
+from _django_app import django_wsgi_app
 from django.db import connections
 from workers import DurableObject
 
@@ -8,9 +9,24 @@ from django_cf.db.backends.do.storage import get_storage
 
 
 class TestDurableObject(DjangoCFDurableObject, DurableObject):
+    def get_app(self):
+        return django_wsgi_app()
+
     @property
     def database(self):
         return connections["do"]
+
+    async def create_orm_table(self):
+        from _do_orm_app import CREATE_DO_TABLE_SQL, DROP_DO_TABLE_SQL
+
+        sql = self.ctx.storage.sql
+        sql.exec(DROP_DO_TABLE_SQL)
+        sql.exec(CREATE_DO_TABLE_SQL)
+
+    async def drop_orm_table(self):
+        from _do_orm_app import DROP_DO_TABLE_SQL
+
+        self.ctx.storage.sql.exec(DROP_DO_TABLE_SQL)
 
     async def test_storage_is_configured(self):
         assert get_storage() is not None


### PR DESCRIPTION
More test improvements using django ORM.

- Adds tests using django orms, such as `model.objects.create()`. Previously what we mostly was using a raw query (`run_query("INSERT ...")`), which was less django-style
- Add test coverage for DO backend + ORMs
- Add test coverage for using Django's [FileField](https://docs.djangoproject.com/en/6.1/topics/files/#using-files-in-models) API, which uses R2 backend internally.