### PR TITLE
feat: asgi.entrypoint syntax sugar for nicer asgi apps

### DIFF
--- a/packages/runtime-sdk/src/workers/asgi.py
+++ b/packages/runtime-sdk/src/workers/asgi.py
@@ -7,7 +7,7 @@ from urllib.parse import unquote
 
 import js
 
-from workers import Context, Request
+from workers import Context, Request, WorkerEntrypoint
 from workers.utils import _to_js_headers
 
 ASGI = {"spec_version": "2.0", "version": "3.0"}
@@ -413,6 +413,18 @@ async def websocket(
     app: Any, req: "Request | js.Request", env: Any = None
 ) -> js.Response:
     return await process_websocket(app, req, env)
+
+
+def entrypoint(app: Any) -> type[WorkerEntrypoint]:
+    """Create the default Worker entrypoint for an ASGI application."""
+
+    class Default(WorkerEntrypoint):
+        async def fetch(self, request):
+            if (request.headers.get("upgrade") or "").lower() == "websocket":
+                return await websocket(app, request, self.env)
+            return await fetch(app, request, self.env, self.ctx)
+
+    return Default
 
 
 def __getattr__(name):

--- a/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/test_routing.py
+++ b/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/test_routing.py
@@ -20,6 +20,15 @@ These are relevant for Pyodide/Workers because:
 
 import pytest
 from _client import fetch, get_json, read_json
+from worker import Default
+
+from workers import WorkerEntrypoint
+
+
+def test_asgi_entrypoint_factory():
+    assert Default.__name__ == "Default"
+    assert issubclass(Default, WorkerEntrypoint)
+
 
 # -- Path parameters ---------------------------------------------------------
 

--- a/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/test_websocket.py
+++ b/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/test_websocket.py
@@ -1,0 +1,39 @@
+import asyncio
+
+import pytest
+from pyodide.ffi import create_proxy
+from worker import Default
+
+from workers import Request
+
+TIMEOUT_S = 5
+_proxies = []
+
+
+@pytest.mark.asyncio
+async def test_generated_entrypoint_serves_fastapi_websocket():
+    entrypoint = object.__new__(Default)
+    entrypoint.env = {}
+    request = Request(
+        "http://testserver/websocket/echo", headers={"Upgrade": "websocket"}
+    )
+
+    response = await entrypoint.fetch(request)
+    assert response.status == 101
+
+    websocket = response.webSocket
+    websocket.accept()
+    message = asyncio.get_event_loop().create_future()
+
+    def onmessage(event):
+        if not message.done():
+            message.set_result(event.data)
+
+    proxy = create_proxy(onmessage)
+    _proxies.append(proxy)
+    websocket.addEventListener("message", proxy)
+    try:
+        websocket.send("hello")
+        assert await asyncio.wait_for(message, TIMEOUT_S) == "echo:hello"
+    finally:
+        websocket.close()

--- a/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/worker.py
+++ b/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/worker.py
@@ -15,6 +15,7 @@ from fastapi import (
     Query,
     Request,
     UploadFile,
+    WebSocket,
 )
 from fastapi.exceptions import HTTPException
 from fastapi.responses import (
@@ -32,7 +33,6 @@ from pyodide.webloop import WebLoop
 from starlette.background import BackgroundTask
 
 import asgi
-from workers import Response, WorkerEntrypoint
 
 
 async def _noop(*args):
@@ -80,6 +80,14 @@ async def api_hello():
 @app.get("/health")
 async def health():
     return {"ok": True}
+
+
+@app.websocket("/websocket/echo")
+async def websocket_echo(websocket: WebSocket):
+    await websocket.accept()
+    message = await websocket.receive_text()
+    await websocket.send_text(f"echo:{message}")
+    await websocket.close()
 
 
 # -- sync route handler (dispatched via run_in_threadpool) -------------------
@@ -447,17 +455,6 @@ async def native_file():
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 
-@app.get("/{path:path}")
-async def frontend(path: str, request: Request):
-    """Proxy static asset requests to the Workers Assets binding."""
-    env = request.scope["env"]
-    asset_url = f"https://assets.local/{path}"
-    resp = await env.ASSETS.fetch(asset_url)
-    body = await resp.bytes()
-    headers = dict(resp.headers)
-    return FastAPIResponse(content=body, status_code=resp.status, headers=headers)
-
-
 class ResultCollector:
     def __init__(self):
         self.results = {}
@@ -524,37 +521,40 @@ class FastAPIAppPlugin:
         return app
 
 
-class Default(WorkerEntrypoint):
-    async def fetch(self, request):
-        from urllib.parse import urlparse
+@app.get("/run-tests/{suite_name:path}")
+async def run_suite(suite_name: str, request: Request):
+    module = f"test_{suite_name}"
+    if importlib.util.find_spec(module) is None:
+        return JSONResponse(
+            {"error": f"Unknown suite '{suite_name}' (no module '{module}')"},
+            status_code=404,
+        )
 
-        path = urlparse(request.url).path
+    collector = ResultCollector()
+    saved_loop = asyncio.events._get_running_loop()
+    try:
+        pytest.main(
+            ["--pyargs", module, "-p", "no:cacheprovider"],
+            plugins=[
+                collector,
+                EnvPlugin(request.scope["env"]),
+                FastAPIAppPlugin(),
+            ],
+        )
+    finally:
+        asyncio.events._set_running_loop(saved_loop)
+    return collector.results
 
-        if path.startswith("/run-tests/"):
-            suite_name = path[len("/run-tests/") :]
-            return self._run_suite(suite_name)
 
-        return await asgi.fetch(app, request, self.env, self.ctx)
+@app.get("/{path:path}")
+async def frontend(path: str, request: Request):
+    """Proxy static asset requests to the Workers Assets binding."""
+    env = request.scope["env"]
+    asset_url = f"https://assets.local/{path}"
+    resp = await env.ASSETS.fetch(asset_url)
+    body = await resp.bytes()
+    headers = dict(resp.headers)
+    return FastAPIResponse(content=body, status_code=resp.status, headers=headers)
 
-    def _run_suite(self, suite_name):
-        module = f"test_{suite_name}"
-        if importlib.util.find_spec(module) is None:
-            return Response.json(
-                {"error": f"Unknown suite '{suite_name}' (no module '{module}')"},
-                status=404,
-            )
 
-        collector = ResultCollector()
-        saved_loop = asyncio.events._get_running_loop()
-        try:
-            pytest.main(
-                ["--pyargs", module, "-p", "no:cacheprovider"],
-                plugins=[
-                    collector,
-                    EnvPlugin(self.env),
-                    FastAPIAppPlugin(),
-                ],
-            )
-        finally:
-            asyncio.events._set_running_loop(saved_loop)
-        return Response.json(collector.results)
+Default = asgi.entrypoint(app)


### PR DESCRIPTION
This changes a fastapi hello world from:

```python
from fastapi import FastAPI

app = FastAPI()

@app.get("/")
def read_root():
    return {"Hello": "World"}

import asgi
from workers import WorkerEntrypoint

class Default(WorkerEntrypoint):
    async def fetch(self, request):
        return await asgi.fetch(app, request, self.env)
```

To:

```python
from fastapi import FastAPI

app = FastAPI()

@app.get("/")
def read_root():
    return {"Hello": "World"}

import asgi
Default = asgi.entrypoint(app)
```

Also adds a websockets fastapi test.