### PR TITLE
chore(django-cf): set DJANGO_ALLOW_ASYNC_UNSAFE to 1 to make it more clear

### DIFF
--- a/packages/django-cf/django_cf/__init__.py
+++ b/packages/django-cf/django_cf/__init__.py
@@ -4,7 +4,7 @@ from workers import wsgi
 
 
 async def handle_wsgi(request, app, env=None):
-    os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "false")
+    os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "1")
 
     return await wsgi.fetch(app, request, env)
 


### PR DESCRIPTION
This is NFC.

Setting `DJANGO_ALLOW_ASYNC_UNSAFE` to any value allows Django to access async-unsafe code (e.g. database access) inside the event loop. Previously, it was set to `false` which gives false impression that the value is not set, but setting any value (false, true, 1, on, etc) to this env var basically enables this config, so changing it to 1 to make it more clear.