### PR TITLE
fix: defer ASGI lifespan shutdown until request completion

### DIFF
--- a/packages/runtime-sdk/src/workers/asgi.py
+++ b/packages/runtime-sdk/src/workers/asgi.py
@@ -186,7 +186,7 @@ async def process_request(  # noqa: PLR0913
     # TODO(later): remove this parameter after unvendoring Python SDK from workerd
     ctx: Context | None,
     state: dict[str, Any] | None = None,
-) -> js.Response:
+) -> tuple[js.Response, Future[None]]:
     from js import Response, TransformStream
     from pyodide.ffi import create_proxy
 
@@ -305,17 +305,22 @@ async def process_request(  # noqa: PLR0913
                     # runtime is waiting on through wait_until.
                     run_in_background(close_stream_quietly(writer))
 
-    # Create task to run the application in the background
-    app_task = create_proxy(create_task(run_app()))
-
-    from workers import wait_until
-
-    wait_until(app_task)
+    request_task = create_task(run_app())
 
     try:
-        return await result
-    finally:
-        app_task.destroy()
+        response = await result
+    except Exception:
+        # The request task handles application exceptions and should be allowed
+        # to finish before its error is propagated to fetch().
+        await request_task
+        raise
+
+    # Buffered responses do not depend on a consumer, so request cleanup can
+    # finish before returning. Streaming responses must run alongside the
+    # consumer because writes can be subject to backpressure.
+    if writer is None:
+        await request_task
+    return response, request_task
 
 
 async def process_websocket(
@@ -427,11 +432,25 @@ async def fetch(
     logger.debug("ASGI request: %s %s", req.method, req.url)
     shutdown, state = await start_application(app)
     try:
-        result = await process_request(app, req, env, ctx, state=state)
+        result, request_task = await process_request(app, req, env, ctx, state=state)
     except Exception:
         logger.exception("ASGI request failed")
+        await shutdown()
         raise
-    await shutdown()
+
+    if request_task.done():
+        await shutdown()
+    else:
+        from workers import wait_until  # noqa: PLC0415
+
+        async def finalize_request():
+            try:
+                await request_task
+            finally:
+                await shutdown()
+
+        wait_until(run_in_background(finalize_request()))
+
     return result
 
 

--- a/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/test_platform_lifecycle.py
+++ b/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/test_platform_lifecycle.py
@@ -1,7 +1,14 @@
-"""FastAPI lifespan state tests targeting the Workers ASGI boundary."""
+"""FastAPI lifecycle tests targeting the Workers ASGI streaming boundary."""
+
+import asyncio
 
 import pytest
-from _client import get_json
+from _client import fetch, get_json
+from worker import (
+    _platform_events,
+    _platform_shutdown_complete,
+    reset_platform_events,
+)
 
 
 @pytest.mark.asyncio
@@ -10,3 +17,30 @@ async def test_lifespan_state_reaches_request(fastapi_app):
     resp, data = await get_json(fastapi_app, "/platform/lifespan-state")
     assert resp.status == 200
     assert data == {"available": True, "closed": False}
+
+
+@pytest.mark.asyncio
+async def test_stream_finishes_before_cleanup_and_shutdown(fastapi_app):
+    """Streaming, background work, and dependency cleanup precede shutdown."""
+    reset_platform_events()
+
+    resp = await asyncio.wait_for(
+        fetch(fastapi_app, "/platform/lifecycle-stream"), timeout=5
+    )
+    assert resp.status == 200
+    assert await asyncio.wait_for(resp.text(), timeout=5) == (
+        "chunk-0\nchunk-1\nchunk-2\n"
+    )
+    await asyncio.wait_for(_platform_shutdown_complete.wait(), timeout=5)
+
+    assert _platform_events == [
+        "lifespan-startup",
+        "dependency-open",
+        "handler",
+        "chunk-0",
+        "chunk-1",
+        "chunk-2",
+        "background-task",
+        "dependency-close",
+        "lifespan-shutdown",
+    ]

--- a/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/worker.py
+++ b/packages/runtime-sdk/tests/web-frameworks-test/fastapi-tests/src/worker.py
@@ -53,13 +53,25 @@ class PlatformResource:
         self.closed = False
 
 
+_platform_events: list[str] = []
+_platform_shutdown_complete = asyncio.Event()
+
+
+def reset_platform_events():
+    _platform_events.clear()
+    _platform_shutdown_complete.clear()
+
+
 @asynccontextmanager
 async def _platform_lifespan(_app):
     resource = PlatformResource()
+    _platform_events.append("lifespan-startup")
     try:
         yield {"platform_resource": resource}
     finally:
         resource.closed = True
+        _platform_events.append("lifespan-shutdown")
+        _platform_shutdown_complete.set()
 
 
 app = FastAPI(lifespan=_platform_lifespan)
@@ -521,6 +533,44 @@ async def platform_gzip_binary():
     return FastAPIResponse(
         content=(bytes(range(256)) * 32),
         media_type="application/octet-stream",
+    )
+
+
+def _stream_resource():
+    resource = PlatformResource()
+    _platform_events.append("dependency-open")
+    try:
+        yield resource
+    finally:
+        resource.closed = True
+        _platform_events.append("dependency-close")
+
+
+async def _platform_background_task():
+    await asyncio.sleep(0)
+    _platform_events.append("background-task")
+
+
+@app.get("/platform/lifecycle-stream")
+async def platform_lifecycle_stream(
+    request: Request,
+    resource: PlatformResource = Depends(_stream_resource),  # noqa: B008
+):
+    lifespan_resource = request.state.platform_resource
+    _platform_events.append("handler")
+
+    async def chunks():
+        for index in range(3):
+            assert not resource.closed
+            assert not lifespan_resource.closed
+            _platform_events.append(f"chunk-{index}")
+            yield f"chunk-{index}\n"
+            await asyncio.sleep(0)
+
+    return StreamingResponse(
+        chunks(),
+        media_type="text/plain",
+        background=BackgroundTask(_platform_background_task),
     )
 
 


### PR DESCRIPTION
FastAPI includes features such as background tasks, streaming responses and dependencies. These can be combined in various ways and it appears that we are not handling their shutdown correctly. 

This PR ensures that we defer ASGI lifespan shutdown until streaming responses, background tasks, and dependency cleanup is complete.

### Test Plan

```
$ uv run pytest 'tests/test_fastapi.py::TestPLATFORM_LIFECYCLE' -v
```