### PR TITLE
fix(django-cf): stop using DJANGO_ALLOW_ASYNC_UNSAFE from django-cf backends

### DIFF
--- a/packages/django-cf/django_cf/__init__.py
+++ b/packages/django-cf/django_cf/__init__.py
@@ -1,11 +1,7 @@
-import os
-
 from workers import wsgi
 
 
 async def handle_wsgi(request, app, env=None):
-    os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "1")
-
     return await wsgi.fetch(app, request, env)
 
 

--- a/packages/django-cf/django_cf/db/_async_unsafe.py
+++ b/packages/django-cf/django_cf/db/_async_unsafe.py
@@ -1,0 +1,33 @@
+"""Helper for removing Django's ``async_unsafe`` guard from backend methods.
+"""
+
+from django.utils import asyncio as _django_asyncio
+
+
+def _async_unsafe_probe():
+    pass
+
+
+# Capture async_unsafe function so we don't accidentally unwrap something else
+_ASYNC_UNSAFE_WRAPPER_CODE = _django_asyncio.async_unsafe(_async_unsafe_probe).__code__
+
+
+def _unwrap_async_unsafe(method):
+    """
+    Unwrap Django's async_unsafe decorator to get the original method.
+
+    This is needed because Django does not allow calling database operations
+    from within an async context, but Python workers always run in an async context.
+
+    All the database backends that django-cf provides are async-safe so we need
+    to unwrap the async_unsafe decorator to allow calling database operations
+    from within an async context.
+    """
+    method_code = getattr(method, "__code__", None)
+    is_async_unsafe = method_code is _ASYNC_UNSAFE_WRAPPER_CODE
+    wrapped = getattr(method, "__wrapped__", None)
+
+    if is_async_unsafe:
+        return wrapped
+
+    return method

--- a/packages/django-cf/django_cf/db/_async_unsafe.py
+++ b/packages/django-cf/django_cf/db/_async_unsafe.py
@@ -1,5 +1,4 @@
-"""Helper for removing Django's ``async_unsafe`` guard from backend methods.
-"""
+"""Helper for removing Django's ``async_unsafe`` guard from backend methods."""
 
 from django.utils import asyncio as _django_asyncio
 

--- a/packages/django-cf/django_cf/db/base_engine.py
+++ b/packages/django-cf/django_cf/db/base_engine.py
@@ -12,6 +12,7 @@ from django.db import (
     OperationalError,
     ProgrammingError,
 )
+from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.sqlite3.base import DatabaseWrapper as SQLiteDatabaseWrapper
 from django.db.backends.sqlite3.client import DatabaseClient as SQLiteDatabaseClient
 from django.db.backends.sqlite3.creation import (
@@ -42,6 +43,7 @@ from django.db.models.functions import (
     TruncYear,
 )
 from django.db.models.sql.compiler import SQLCompiler
+from django.utils import asyncio as _django_asyncio
 
 
 def replace_date_trunc_in_sql(sql):
@@ -479,6 +481,35 @@ class CFSQLCompiler(SQLCompiler):
         return sql, params
 
 
+def _async_unsafe_probe():
+    pass
+
+
+# Capture async_unsafe function so we don't accidentally unwrap something else
+_ASYNC_UNSAFE_WRAPPER_CODE = _django_asyncio.async_unsafe(_async_unsafe_probe).__code__
+
+
+def _unwrap_async_unsafe(method):
+    """
+    Unwrap Django's async_unsafe decorator to get the original method.
+
+    This is needed because Django does not allow calling database operations
+    from within an async context, but Python workers always run in an async context.
+
+    All the database backends that django-cf provides are async-safe so we need
+    to unwrap the async_unsafe decorator to allow calling database operations
+    from within an async context.
+    """
+    method_code = getattr(method, "__code__", None)
+    is_async_unsafe = method_code is _ASYNC_UNSAFE_WRAPPER_CODE
+    wrapped = getattr(method, "__wrapped__", None)
+
+    if is_async_unsafe:
+        return wrapped
+
+    return method
+
+
 class CFDatabaseWrapper(SQLiteDatabaseWrapper):
     # this is defined in the class extending this one
     # vendor = "cloudflare_d1"
@@ -495,6 +526,16 @@ class CFDatabaseWrapper(SQLiteDatabaseWrapper):
     ops_class = CFDatabaseOperations
 
     transaction_modes = frozenset([])
+
+    connect = _unwrap_async_unsafe(BaseDatabaseWrapper.connect)
+    ensure_connection = _unwrap_async_unsafe(BaseDatabaseWrapper.ensure_connection)
+    cursor = _unwrap_async_unsafe(BaseDatabaseWrapper.cursor)
+    commit = _unwrap_async_unsafe(BaseDatabaseWrapper.commit)
+    rollback = _unwrap_async_unsafe(BaseDatabaseWrapper.rollback)
+    savepoint = _unwrap_async_unsafe(BaseDatabaseWrapper.savepoint)
+    savepoint_rollback = _unwrap_async_unsafe(BaseDatabaseWrapper.savepoint_rollback)
+    savepoint_commit = _unwrap_async_unsafe(BaseDatabaseWrapper.savepoint_commit)
+    clean_savepoints = _unwrap_async_unsafe(BaseDatabaseWrapper.clean_savepoints)
 
     def get_compiler(self, default_using=None, using=None, **kwargs):
         if using is None:

--- a/packages/django-cf/django_cf/db/base_engine.py
+++ b/packages/django-cf/django_cf/db/base_engine.py
@@ -43,7 +43,8 @@ from django.db.models.functions import (
     TruncYear,
 )
 from django.db.models.sql.compiler import SQLCompiler
-from django.utils import asyncio as _django_asyncio
+
+from ._async_unsafe import _unwrap_async_unsafe
 
 
 def replace_date_trunc_in_sql(sql):
@@ -479,35 +480,6 @@ class CFSQLCompiler(SQLCompiler):
 
         sql = templates.get(kind, field_sql)
         return sql, params
-
-
-def _async_unsafe_probe():
-    pass
-
-
-# Capture async_unsafe function so we don't accidentally unwrap something else
-_ASYNC_UNSAFE_WRAPPER_CODE = _django_asyncio.async_unsafe(_async_unsafe_probe).__code__
-
-
-def _unwrap_async_unsafe(method):
-    """
-    Unwrap Django's async_unsafe decorator to get the original method.
-
-    This is needed because Django does not allow calling database operations
-    from within an async context, but Python workers always run in an async context.
-
-    All the database backends that django-cf provides are async-safe so we need
-    to unwrap the async_unsafe decorator to allow calling database operations
-    from within an async context.
-    """
-    method_code = getattr(method, "__code__", None)
-    is_async_unsafe = method_code is _ASYNC_UNSAFE_WRAPPER_CODE
-    wrapped = getattr(method, "__wrapped__", None)
-
-    if is_async_unsafe:
-        return wrapped
-
-    return method
 
 
 class CFDatabaseWrapper(SQLiteDatabaseWrapper):

--- a/packages/django-cf/tests/in_worker/worker/src/test_base_engine.py
+++ b/packages/django-cf/tests/in_worker/worker/src/test_base_engine.py
@@ -6,6 +6,10 @@ from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.db.backends.base.base import BaseDatabaseWrapper
+from django.utils.asyncio import async_unsafe
+
+from django_cf.db.base_engine import CFDatabaseWrapper, _unwrap_async_unsafe
 
 
 class TestCFResult:
@@ -547,7 +551,42 @@ class TestCFDatabaseFeatures:
         assert features.can_return_columns_from_insert is True
 
 
+class TestUnwrapAsyncUnsafe:
+    def test_removes_async_unsafe_guard(self):
+        def target():
+            return "called"
+
+        guarded = async_unsafe(target)
+
+        assert _unwrap_async_unsafe(guarded) is target
+
+    def test_returns_undecorated_method_unchanged(self):
+        def target():
+            return "called"
+
+        assert _unwrap_async_unsafe(target) is target
+
+
 class TestCFDatabaseWrapper:
+    def test_connection_lifecycle_is_not_guarded_by_async_unsafe(self):
+        method_names = (
+            "connect",
+            "ensure_connection",
+            "cursor",
+            "commit",
+            "rollback",
+            "savepoint",
+            "savepoint_rollback",
+            "savepoint_commit",
+            "clean_savepoints",
+        )
+
+        for method_name in method_names:
+            guarded_method = getattr(BaseDatabaseWrapper, method_name)
+            assert getattr(CFDatabaseWrapper, method_name) is _unwrap_async_unsafe(
+                guarded_method
+            )
+
     def test_get_database_version(self):
         from django_cf.db.base_engine import CFDatabaseWrapper
 

--- a/packages/django-cf/tests/in_worker/worker/src/worker.py
+++ b/packages/django-cf/tests/in_worker/worker/src/worker.py
@@ -4,7 +4,6 @@ import asyncio
 import contextlib
 import importlib.util
 import io
-import os
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -19,7 +18,6 @@ from worker_durable_object import TestDurableObject  # noqa: F401
 from workers import Response, WorkerEntrypoint
 
 BASE_DIR = Path(__file__).parent
-os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
 
 
 async def _noop(*args):


### PR DESCRIPTION
Stop using discouraged `DJANGO_ALLOW_ASYNC_UNSAFE` flag and mark django-cf backends async-safe.

Since django by default wraps all the database methods with `@async_unsafe` decorator, this includes a slightly hacky solution that unwraps decorators of those methods.