### PR TITLE
fix(runtime-sdk): chain the app's exception onto a reported lifespan failure

### DIFF
--- a/packages/runtime-sdk/src/workers/asgi.py
+++ b/packages/runtime-sdk/src/workers/asgi.py
@@ -165,6 +165,16 @@ async def start_application(app):
             if not startup.done():
                 startup.set_result(False)
                 return
+            # Frameworks re-raise the original right after sending the failed
+            # event, with no await in between, so the awaiter has not resumed
+            # and the attachment still reaches it as the cause:
+            # https://github.com/encode/starlette/blob/1.3.1/starlette/routing.py
+            for reported in (startup, shutdown_complete):
+                if reported.done() and not reported.cancelled():
+                    failure = reported.exception()
+                    if failure is not None:
+                        failure.__cause__ = exc
+                        return
             # After a successful startup, a shutdown-phase error can't affect the
             # already-served request, so log it and let shutdown complete.
             logger.exception("Exception in ASGI lifespan application", exc_info=exc)

--- a/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
@@ -396,6 +396,70 @@ async def _scope(path):
     return json.loads(await response.text())
 
 
+class _StartupFailWithCauseApp:
+    """Starlette-style failure: send startup.failed, then re-raise the error."""
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                try:
+                    raise ValueError("real startup error")
+                except ValueError:
+                    await send(
+                        {
+                            "type": "lifespan.startup.failed",
+                            "message": "startup failed",
+                        }
+                    )
+                    raise
+
+
+@pytest.mark.asyncio
+async def test_lifespan_startup_failure_chains_the_apps_exception():
+    req = js.Request.new("http://example.com/startup-fail-cause")
+    with pytest.raises(RuntimeError, match="startup failed") as excinfo:
+        await asyncio.wait_for(
+            asgi.fetch(_StartupFailWithCauseApp(), req, env), timeout=5
+        )
+    assert isinstance(excinfo.value.__cause__, ValueError)
+    assert "real startup error" in str(excinfo.value.__cause__)
+
+
+class _ShutdownFailWithCauseApp:
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            while True:
+                message = await receive()
+                if message["type"] == "lifespan.startup":
+                    await send({"type": "lifespan.startup.complete"})
+                elif message["type"] == "lifespan.shutdown":
+                    try:
+                        raise ValueError("real shutdown error")
+                    except ValueError:
+                        await send(
+                            {
+                                "type": "lifespan.shutdown.failed",
+                                "message": "shutdown failed",
+                            }
+                        )
+                        raise
+        await receive()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+
+@pytest.mark.asyncio
+async def test_lifespan_shutdown_failure_chains_the_apps_exception():
+    req = js.Request.new("http://example.com/shutdown-fail-cause")
+    with pytest.raises(RuntimeError, match="shutdown failed") as excinfo:
+        await asyncio.wait_for(
+            asgi.fetch(_ShutdownFailWithCauseApp(), req, env), timeout=5
+        )
+    assert isinstance(excinfo.value.__cause__, ValueError)
+    assert "real shutdown error" in str(excinfo.value.__cause__)
+
+
 @pytest.mark.asyncio
 async def test_scope_path_is_percent_decoded():
     scope = await _scope("/scope/hello%20world")


### PR DESCRIPTION
When an app reports `lifespan.startup.failed`, the caller gets a `RuntimeError` carrying only the message text, so the app's own exception object reaches nobody. This attaches it as the reported error's `__cause__`, on the startup and shutdown paths alike.

### Test Plan

```
$ uv run pytest 'tests/test_in_workerd.py::test_in_workerd[asgi-3.13]' -v
```

(run from `packages/runtime-sdk`)