### PR TITLE
feat(runtime-sdk): add `lifespan="worker"` to `asgi.fetch` for a worker-lifetime lifespan

### DIFF
--- a/packages/runtime-sdk/src/workers/asgi.py
+++ b/packages/runtime-sdk/src/workers/asgi.py
@@ -1,8 +1,9 @@
+import asyncio
 import logging
 from asyncio import Event, Future, Queue, create_task, ensure_future
 from collections.abc import Awaitable
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import unquote
 
 import js
@@ -91,6 +92,70 @@ def request_to_scope(req, env, ws=False, state=None):
         # ASGI requires a shallow copy of lifespan state for each request.
         scope["state"] = dict(state)
     return scope
+
+
+async def _no_shutdown() -> None:
+    return
+
+
+# How long a request waits on a startup another request began, before giving up
+# and letting the next request re-drive it. See _ensure_worker_lifespan.
+WORKER_LIFESPAN_STARTUP_TIMEOUT = 30.0
+
+# Keyed by id(app), holding the app itself alongside the value: an id is only
+# unique among live objects, so a collected app could hand its id, and another
+# app's lifespan state, to an unrelated object. Keeping it alive costs nothing
+# here, since worker mode means the app lives as long as the isolate.
+_worker_lifespans: dict[int, tuple[Any, Future]] = {}
+_worker_lifespan_states: dict[int, tuple[Any, dict[str, Any]]] = {}
+
+
+def _forget_worker_lifespan(app: Any, fut: Future) -> None:
+    cached = _worker_lifespans.get(id(app))
+    if cached is not None and cached[1] is fut:
+        del _worker_lifespans[id(app)]
+
+
+async def _ensure_worker_lifespan(app: Any) -> dict[str, Any]:
+    cached_state = _worker_lifespan_states.get(id(app))
+    if cached_state is not None:
+        # workerd drops promise continuations scheduled onto a dead IoContext
+        # (compat flag handle_cross_request_promise_resolution, enabled by date
+        # since 2024-10-14), so once startup is done the state is read directly
+        # rather than by awaiting a future an earlier request created.
+        # Concurrent cold starts below still take that risk.
+        return cached_state[1]
+
+    # Concurrent cold-start requests share one startup instead of each driving
+    # its own lifespan cycle.
+    cached = _worker_lifespans.get(id(app))
+    if cached is None:
+        fut = ensure_future(start_application(app))
+        _worker_lifespans[id(app)] = (app, fut)
+    else:
+        fut = cached[1]
+    try:
+        # Shielded so that one waiter timing out or being cancelled does not
+        # cancel the startup the other waiters are relying on. Bounded because
+        # a waiter here is on the dropped-continuation path described above, so
+        # without a deadline it could wait forever, and so would every request
+        # after it.
+        _shutdown, state = await asyncio.wait_for(
+            asyncio.shield(fut), WORKER_LIFESPAN_STARTUP_TIMEOUT
+        )
+    except TimeoutError as exc:
+        _forget_worker_lifespan(app, fut)
+        raise RuntimeError(
+            "ASGI lifespan startup did not complete within "
+            f"{WORKER_LIFESPAN_STARTUP_TIMEOUT}s; the next request will retry it"
+        ) from exc
+    except BaseException:
+        # Drop the failed startup so the next request retries, rather than
+        # turning one transient cold-start error into permanent failures.
+        _forget_worker_lifespan(app, fut)
+        raise
+    _worker_lifespan_states[id(app)] = (app, state)
+    return state
 
 
 async def start_application(app):
@@ -436,10 +501,20 @@ async def process_websocket(
 
 
 async def fetch(
-    app: Any, req: "Request | js.Request", env: Any, ctx: Context | None = None
+    app: Any,
+    req: "Request | js.Request",
+    env: Any,
+    ctx: Context | None = None,
+    *,
+    lifespan: Literal["request", "worker"] = "request",
 ) -> js.Response:
     logger.debug("ASGI request: %s %s", req.method, req.url)
-    shutdown, state = await start_application(app)
+    if lifespan == "worker":
+        shutdown, state = _no_shutdown, await _ensure_worker_lifespan(app)
+    elif lifespan == "request":
+        shutdown, state = await start_application(app)
+    else:
+        raise ValueError(f"Unsupported lifespan mode: {lifespan!r}")
     try:
         result, request_task = await process_request(app, req, env, ctx, state=state)
     except Exception:

--- a/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
@@ -474,3 +474,38 @@ async def test_lifespan_preack_crash_is_logged_and_treated_as_unsupported():
         )
     finally:
         _remove_handler(handler)
+
+
+async def _startup_count(path):
+    response = await asyncio.wait_for(
+        env.SELF.fetch(f"http://example.com{path}"), timeout=5
+    )
+    return await response.text()
+
+
+@pytest.mark.asyncio
+async def test_worker_lifespan_starts_the_app_once():
+    assert await _startup_count("/lifespan-worker") == "1"
+    assert await _startup_count("/lifespan-worker") == "1"
+
+
+@pytest.mark.asyncio
+async def test_request_lifespan_starts_the_app_every_time():
+    first = int(await _startup_count("/lifespan-request"))
+    assert int(await _startup_count("/lifespan-request")) == first + 1
+
+
+@pytest.mark.asyncio
+async def test_worker_lifespan_streams_the_whole_body():
+    # A streaming response returns before its app task finishes.
+    response = await asyncio.wait_for(
+        env.SELF.fetch("http://example.com/lifespan-worker-stream"), timeout=5
+    )
+    body = await asyncio.wait_for(response.bytes(), timeout=5)
+    assert len(body) == STREAMING_CHUNK_SIZE * STREAMING_NUM_CHUNKS
+
+
+@pytest.mark.asyncio
+async def test_worker_lifespan_accepts_an_unhashable_app():
+    assert await _startup_count("/lifespan-worker-unhashable") == "1"
+    assert await _startup_count("/lifespan-worker-unhashable") == "1"

--- a/packages/runtime-sdk/tests/workerd-test/asgi/worker.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi/worker.py
@@ -205,6 +205,67 @@ class LateFailureStreamApp:
         raise RuntimeError("app failed mid-stream")
 
 
+class UnhashableLifespanApp:
+    """Unhashable and not weak-referenceable, which worker mode must accept."""
+
+    __slots__ = ("startup_count",)
+    __hash__ = None
+
+    def __init__(self):
+        self.startup_count = 0
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            while True:
+                message = await receive()
+                if message["type"] == "lifespan.startup":
+                    self.startup_count += 1
+                    await send({"type": "lifespan.startup.complete"})
+                elif message["type"] == "lifespan.shutdown":
+                    await send({"type": "lifespan.shutdown.complete"})
+                    return
+        await receive()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send(
+            {"type": "http.response.body", "body": str(self.startup_count).encode()}
+        )
+
+
+class CountingLifespanApp:
+    """Reports how many times its lifespan has been started."""
+
+    def __init__(self):
+        self.startup_count = 0
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            while True:
+                message = await receive()
+                if message["type"] == "lifespan.startup":
+                    self.startup_count += 1
+                    scope["state"]["startup_count"] = self.startup_count
+                    await send({"type": "lifespan.startup.complete"})
+                elif message["type"] == "lifespan.shutdown":
+                    await send({"type": "lifespan.shutdown.complete"})
+                    return
+        await receive()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                # Read back through the scope, so the test covers the lifespan
+                # state reaching a later request rather than just the instance.
+                "body": str(scope["state"]["startup_count"]).encode(),
+            }
+        )
+
+
 class ScopeEchoApp:
     """Echoes selected scope fields as JSON so tests can inspect them."""
 
@@ -260,6 +321,9 @@ app = HeaderEchoApp()
 sse_app = SSEApp()
 streaming_app = StreamingApp()
 scope_echo_app = ScopeEchoApp()
+worker_lifespan_app = CountingLifespanApp()
+request_lifespan_app = CountingLifespanApp()
+unhashable_lifespan_app = UnhashableLifespanApp()
 late_failure_stream_app = LateFailureStreamApp()
 multi_cookie_app = MultiCookieApp()
 
@@ -279,6 +343,20 @@ class Default(WorkerEntrypoint):
             return await asgi.fetch(streaming_app, request, self.env, self.ctx)
         elif path.startswith("/scope"):
             return await asgi.fetch(scope_echo_app, request, self.env, self.ctx)
+        elif path == "/lifespan-worker":
+            return await asgi.fetch(
+                worker_lifespan_app, request, self.env, self.ctx, lifespan="worker"
+            )
+        elif path == "/lifespan-worker-unhashable":
+            return await asgi.fetch(
+                unhashable_lifespan_app, request, self.env, self.ctx, lifespan="worker"
+            )
+        elif path == "/lifespan-worker-stream":
+            return await asgi.fetch(
+                streaming_app, request, self.env, self.ctx, lifespan="worker"
+            )
+        elif path == "/lifespan-request":
+            return await asgi.fetch(request_lifespan_app, request, self.env, self.ctx)
         elif path == "/stream-late-failure":
             return await asgi.fetch(
                 late_failure_stream_app, request, self.env, self.ctx


### PR DESCRIPTION
> **Not merge-ready.** This is a proposal, opened to discuss a new feature that needs a maintainer decision on the design. The open questions at the end are the parts I would want settled before this is worth merging.

`asgi.fetch` runs a full lifespan startup and shutdown around every request. That is right for a stateless app, but an app whose lifespan owns state meant to outlive a request (a connection pool, a warmed cache, a model loaded once, the session state behind a WebSocket) rebuilds it on each call and tears it down again.

This adds an opt-in mode, with the default unchanged:

```python
asgi.fetch(app, request, env, ctx, lifespan="worker")   # default: "request"
```

`"worker"` starts the app's lifespan once per isolate and leaves it running, so the state the lifespan populates reaches every later request through `scope["state"]`, which each request still receives as its own shallow copy. Concurrent cold-start requests share one startup rather than each driving its own, and a failed startup is dropped so the next request retries instead of one transient error becoming permanent.

<!-- Nothing here asks for a guarantee that the state survives: an isolate can be evicted at any time, the app's `lifespan.shutdown` never runs in this mode, and an app must treat the state as a cache it can rebuild. The mode exists because the platform already supports work outliving a request, while an ASGI app on it cannot. -->

### Discussions

1. **Shutdown.** There is no isolate-teardown hook provided from CF Workers, so `lifespan.shutdown` is never sent.
2. **Waiting on a startup another request began.** A request arriving during cold start waits on a future created in the first request's IoContext, and workerd drops that wake-up once the first request has ended (`handle_cross_request_promise_resolution`). The future stays cached unresolved, so every later request waits on it too and the app never starts in that isolate. There is no exposure after startup completes, since the state is cached as a plain value from then on.

   Disabling the compat flag would bring back the bugs it prevents, so `_ensure_worker_lifespan` bounds the wait instead and forgets the cached future on expiry, turning a dead isolate into one failed request and a retry.

   Is a deadline the right shape, or is there a better handoff between contexts? `WORKER_LIFESPAN_STARTUP_TIMEOUT` defaults to 30s, which is a guess: too low re-drives a slow cold start and starts the app twice.

3. **API shape.** The mode is a keyword on `fetch`, so the SDK caches the lifespan in a module-level dict keyed by the app. An explicit holder would put that lifetime in the caller's hands instead:

   ```python
   resident = asgi.WorkerLifespan(app)   # module scope, so isolate scope
   ...
   return await resident.fetch(request, env, ctx)
   ```

   That drops the SDK-side globals, makes "once per isolate" visible in the user's own code rather than implied, and reaches `asgi.entrypoint`, which hardcodes `fetch(...)` and so cannot opt into the keyword form at all. The cost is new public API surface. I went with the keyword because it is the smaller change, but the holder shape may be the better one to live with.

### Test Plan

```
$ uv run pytest 'tests/test_in_workerd.py::test_in_workerd[asgi-3.13]' -v
```

(run from `packages/runtime-sdk`)

The in-worker harness runs everything inside one long-lived request, so two things it cannot show: a response body truncated by a missing `waitUntil`, and the bounded wait above doing its job (workerd cancels the hung sub-request on its own before the deadline matters). The streaming test covers the mode working rather than those regressions, and the timeout is unverified by the suite.



