### PR TITLE
fix(django-cf): remove redundant to_py() calls from r2 and do

### DIFF
--- a/packages/django-cf/django_cf/db/backends/do/base.py
+++ b/packages/django-cf/django_cf/db/backends/do/base.py
@@ -46,7 +46,7 @@ class DatabaseWrapper(CFDatabaseWrapper):
             stmt = db.exec(proc_query)
 
         try:
-            response = stmt.raw().toArray().to_py()
+            response = stmt.raw().toArray()
             result = CFResult.from_object(
                 query, params, response, stmt.rowsRead, stmt.rowsWritten
             )

--- a/packages/django-cf/django_cf/storage/r2.py
+++ b/packages/django-cf/django_cf/storage/r2.py
@@ -157,7 +157,7 @@ class R2Storage(Storage):
         full_path = self._full_path(name)
         try:
             bucket = self._get_bucket()
-            result = self._run_sync(bucket.head(full_path)).to_py()
+            result = self._run_sync(bucket.head(full_path))
             return result is not None
         except Exception:
             return False
@@ -199,7 +199,7 @@ class R2Storage(Storage):
         full_path = self._full_path(name)
         try:
             bucket = self._get_bucket()
-            metadata = self._run_sync(bucket.head(full_path)).to_py()
+            metadata = self._run_sync(bucket.head(full_path))
             if metadata and hasattr(metadata, "size"):
                 return metadata.size
             return 0
@@ -246,7 +246,7 @@ class R2Storage(Storage):
         full_path = self._full_path(name)
         try:
             bucket = self._get_bucket()
-            metadata = self._run_sync(bucket.head(full_path)).to_py()
+            metadata = self._run_sync(bucket.head(full_path))
 
             if metadata and hasattr(metadata, "uploaded"):
                 uploaded = metadata.uploaded

--- a/packages/django-cf/tests/in_worker/worker/src/test_storage_errors.py
+++ b/packages/django-cf/tests/in_worker/worker/src/test_storage_errors.py
@@ -109,6 +109,16 @@ class TestR2StorageReadErrors:
 
 
 class TestR2StorageExistsErrors:
+    def test_exists_returns_true_for_existing_file(self):
+        storage = make_live_r2_storage(location=unique_name("r2-existing-exists"))
+        name = "file.txt"
+        save_bytes(storage, name, b"content")
+
+        try:
+            assert storage.exists(name) is True
+        finally:
+            storage.delete(name)
+
     def test_exists_returns_false_on_not_found(self):
         storage = make_live_r2_storage(location=unique_name("r2-missing-exists"))
 
@@ -116,6 +126,17 @@ class TestR2StorageExistsErrors:
 
 
 class TestR2StorageSizeErrors:
+    def test_size_returns_existing_file_size(self):
+        storage = make_live_r2_storage(location=unique_name("r2-existing-size"))
+        name = "file.txt"
+        content = b"test content"
+        save_bytes(storage, name, content)
+
+        try:
+            assert storage.size(name) == len(content)
+        finally:
+            storage.delete(name)
+
     def test_size_returns_zero_on_not_found(self):
         storage = make_live_r2_storage(location=unique_name("r2-missing-size"))
 

--- a/packages/django-cf/tests/in_worker/worker/src/worker_durable_object.py
+++ b/packages/django-cf/tests/in_worker/worker/src/worker_durable_object.py
@@ -9,6 +9,9 @@ from django_cf.db.backends.do.storage import get_storage
 
 
 class TestDurableObject(DjangoCFDurableObject, DurableObject):
+    def __init__(self, ctx, env):
+        super().__init__(ctx, env)
+
     def get_app(self):
         return django_wsgi_app()
 
@@ -29,6 +32,9 @@ class TestDurableObject(DjangoCFDurableObject, DurableObject):
         self.ctx.storage.sql.exec(DROP_DO_TABLE_SQL)
 
     async def test_storage_is_configured(self):
+        from workers.entrypoints import DurableObjectContext
+
+        assert isinstance(self.ctx, DurableObjectContext)
         assert get_storage() is not None
 
     async def test_run_query_uses_configured_storage(self):
@@ -37,6 +43,10 @@ class TestDurableObject(DjangoCFDurableObject, DurableObject):
         sql.exec(f"DROP TABLE IF EXISTS {table}")
         sql.exec(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY, value TEXT)")
         sql.exec(f"INSERT INTO {table} VALUES (?, ?)", 1, "ok")
+
+        rows = sql.exec(f"SELECT id, value FROM {table}").raw().toArray()
+        assert isinstance(rows, list)
+        assert rows == [[1, "ok"]]
 
         result = self.database.run_query(
             f"SELECT id, value FROM {table} WHERE id = %s", [1]


### PR DESCRIPTION
These are unnecessary and rather causing errors after we updated our SDK to convert types internally.