### PR TITLE
test(runtime-sdk): enable fastapi tests in python 3.14

### DIFF
--- a/packages/runtime-sdk/tests/test_fastapi.py
+++ b/packages/runtime-sdk/tests/test_fastapi.py
@@ -4,9 +4,6 @@ Python 3.12 (Pyodide 0.26.0a2) is excluded. The in-worker pytest suite drives
 async tests via ``loop.run_until_complete``, which is a no-op on Pyodide 0.26.0a2
 (no ``run_sync``/JSPI): async tests return unawaited futures and report false
 passes.
-
-Python 3.14 is excluded because pydantic_core has a circular import error on
-the 3.14 Pyodide runtime (``validate_core_schema`` not found during module init).
 """
 
 from pathlib import Path
@@ -26,9 +23,8 @@ def worker_project_dir() -> Path:
 
 
 # Exclude Python 3.12 (Pyodide 0.26.0a2) for async tests.
-# Exclude Python 3.14 due to pydantic_core circular import error on Pyodide.
 FASTAPI_COMPAT_CONFIGS = [
-    c for c in COMPAT_CONFIGS if c.python_version not in ("3.12", "3.14")
+    c for c in COMPAT_CONFIGS if c.python_version not in ("3.12",)
 ]
 
 


### PR DESCRIPTION
This works now after (#132)