### PR TITLE
fix(cli): update Pyodide index version for Python 3.14 to 314.0.6

### DIFF
--- a/packages/cli/src/pywrangler/utils.py
+++ b/packages/cli/src/pywrangler/utils.py
@@ -424,7 +424,7 @@ def get_pyodide_index() -> str:
         case "3.13":
             v = "0.28.3"
         case "3.14":
-            v = "314.0.2"
+            v = "314.0.6"
     return "https://index.pyodide.org/" + v
 
 


### PR DESCRIPTION
`314.0.6` includes cross-compiled psycopg and mysqlclient packages.