### PR TITLE
test(runtime-sdk): test aiomysql, psycopg and asyncpg + hyperdrive

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,14 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
-        python-version: '3.13'
+        python-version: '3.14'
+
+    # needed to build psycopg-c from source
+    # TODO(soon): maybe allow pywrangler to skip native package installs
+    # when not needed. Native installations are just for validation + type hints
+    # and are not used at all in the runtime.
+    - name: Install libpq development files
+      run: sudo apt-get update && sudo apt-get install --yes libpq-dev
 
     - name: Run Hyperdrive binding tests
       working-directory: packages/runtime-sdk

--- a/packages/cli/src/pywrangler/utils.py
+++ b/packages/cli/src/pywrangler/utils.py
@@ -424,7 +424,7 @@ def get_pyodide_index() -> str:
         case "3.13":
             v = "0.28.3"
         case "3.14":
-            v = "314.0.2"
+            v = "314.0.6"
     return "https://index.pyodide.org/" + v
 
 

--- a/packages/runtime-sdk/tests/bindings-test/pyproject.toml
+++ b/packages/runtime-sdk/tests/bindings-test/pyproject.toml
@@ -6,12 +6,18 @@ dependencies = [
     "pytest",
     "pytest-asyncio<1.2.0",
     # These are for hyperdrive tests
-    "pg8000; python_version >= '3.14'",
-    "pymysql; python_version >= '3.14'",
-    "aiomysql; python_version >= '3.14'",
+dependencies = [
+    "pytest",
+    "pytest-asyncio<1.2.0",
+    # These are for hyperdrive tests
+    "pg8000",
+    "pymysql",
+    "aiomysql",
     "psycopg; python_version >= '3.14'",
     "psycopg-c; python_version >= '3.14'",
-    "cryptography; python_version >= '3.14'",
+    "cryptography",
+    "testlib",
+]
     "testlib",
 ]
 

--- a/packages/runtime-sdk/tests/bindings-test/pyproject.toml
+++ b/packages/runtime-sdk/tests/bindings-test/pyproject.toml
@@ -2,7 +2,18 @@
 name = "bindings-test"
 version = "0.1.0"
 requires-python = ">=3.12"
-dependencies = ["pytest", "pytest-asyncio<1.2.0", "pg8000", "pymysql", "cryptography", "testlib"]
+dependencies = [
+    "pytest",
+    "pytest-asyncio<1.2.0",
+    # These are for hyperdrive tests
+    "pg8000; python_version >= '3.14'",
+    "pymysql; python_version >= '3.14'",
+    "aiomysql; python_version >= '3.14'",
+    "psycopg; python_version >= '3.14'",
+    "psycopg-c; python_version >= '3.14'",
+    "cryptography; python_version >= '3.14'",
+    "testlib",
+]
 
 [tool.uv.sources]
 testlib = { path = "../testlib/dist/testlib-0.0.0-py3-none-any.whl" }

--- a/packages/runtime-sdk/tests/bindings-test/pyproject.toml
+++ b/packages/runtime-sdk/tests/bindings-test/pyproject.toml
@@ -6,18 +6,12 @@ dependencies = [
     "pytest",
     "pytest-asyncio<1.2.0",
     # These are for hyperdrive tests
-dependencies = [
-    "pytest",
-    "pytest-asyncio<1.2.0",
-    # These are for hyperdrive tests
     "pg8000",
     "pymysql",
     "aiomysql",
     "psycopg; python_version >= '3.14'",
     "psycopg-c; python_version >= '3.14'",
     "cryptography",
-    "testlib",
-]
     "testlib",
 ]
 

--- a/packages/runtime-sdk/tests/bindings-test/src/test_hyperdrive_mysql.py
+++ b/packages/runtime-sdk/tests/bindings-test/src/test_hyperdrive_mysql.py
@@ -24,6 +24,7 @@ uv run pytest tests/test_bindings.py -m hyperdrive -k mysql
 
 import sys
 
+import aiomysql
 import pymysql
 import pytest
 from conftest import unique_table_name
@@ -56,6 +57,26 @@ async def test_connect(env):
     cur.execute("SELECT 1")
     assert cur.fetchone() == (1,)
     conn.close()
+
+
+@pytest.mark.asyncio
+async def test_connect_aiomysql(env):
+    hd = env.HYPERDRIVE_MYSQL
+    conn = await aiomysql.connect(
+        host=hd.host,
+        port=int(hd.port),
+        user=hd.user,
+        password=hd.password,
+        db=hd.database,
+        # Hyperdrive terminates TLS to the origin, so this hop is plaintext.
+        ssl=None,
+    )
+    try:
+        async with conn.cursor() as cur:
+            await cur.execute("SELECT %s", (1,))
+            assert await cur.fetchone() == (1,)
+    finally:
+        await conn.ensure_closed()
 
 
 @pytest.mark.asyncio

--- a/packages/runtime-sdk/tests/bindings-test/src/test_hyperdrive_postgresql.py
+++ b/packages/runtime-sdk/tests/bindings-test/src/test_hyperdrive_postgresql.py
@@ -22,6 +22,11 @@ Then run the test:
 
 uv run pytest tests/test_bindings.py -m hyperdrive -k postgresql
 
+Host prerequisites for the psycopg C extension:
+
+Ubuntu: sudo apt-get install libpq-dev
+macOS: brew install libpq && export PATH="$(brew --prefix libpq)/bin:$PATH"
+
 Note: "POSTGRES_HOST_AUTH_METHOD=md5" is required for PostgreSQL to work with pg8000, since the
       default `scram-sha-256` is not available in the pg8000 with Python workers (missing openssl)
 """
@@ -59,6 +64,26 @@ async def test_connect(env):
     cur.execute("SELECT 1")
     assert cur.fetchone() == [1]
     conn.close()
+
+
+@pytest.mark.asyncio
+async def test_connect_psycopg(env):
+    import psycopg  # noqa: PLC0415
+
+    assert psycopg.pq.__impl__ == "c"
+    hd = env.HYPERDRIVE_PG
+    with psycopg.connect(
+        host=hd.host,
+        port=int(hd.port),
+        user=hd.user,
+        password=hd.password,
+        dbname=hd.database,
+        # Hyperdrive terminates TLS to the origin, so this hop is plaintext.
+        sslmode="disable",
+    ) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT %s", (1,))
+            assert cur.fetchone() == (1,)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds a smoke test for `aiomysql` and `psycopg` which are also famous Python database drivers.