### PR TITLE
fix(runtime-sdk): retain the ASGI finalizer proxy until completion

### DIFF
--- a/packages/runtime-sdk/src/workers/asgi.py
+++ b/packages/runtime-sdk/src/workers/asgi.py
@@ -458,7 +458,14 @@ async def fetch(
             finally:
                 await shutdown()
 
-        wait_until(run_in_background(finalize_request()))
+        from pyodide.ffi import create_proxy  # noqa: PLC0415
+
+        # waitUntil retains the task after returning to Python. A borrowed
+        # proxy expires before JavaScript can finish assimilating the task.
+        finalizer = run_in_background(finalize_request())
+        finalizer_proxy = create_proxy(finalizer)
+        finalizer.add_done_callback(lambda finished: finalizer_proxy.destroy())
+        wait_until(finalizer_proxy)
 
     return result
 

--- a/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
@@ -8,6 +8,7 @@ from pyodide.ffi import to_js
 from worker import STREAMING_CHUNK_SIZE, STREAMING_NUM_CHUNKS, example_hdr
 
 import asgi
+import workers
 from workers import Request, env
 from workers import asgi as workers_asgi
 
@@ -474,3 +475,47 @@ async def test_lifespan_preack_crash_is_logged_and_treated_as_unsupported():
         )
     finally:
         _remove_handler(handler)
+
+
+@pytest.mark.asyncio
+async def test_stream_finalizer_proxy_survives_javascript_retention(monkeypatch):
+    # Array.push, like waitUntil, retains its argument and returns no Promise.
+    # Reading it after fetch returns exposes a borrowed proxy's destruction;
+    # awaiting response.text() alone can pass while waitUntil rejects the task.
+    retained = js.Array.new()
+    monkeypatch.setattr(workers, "wait_until", retained.push)
+    release = asyncio.Event()
+    events = []
+
+    async def app(scope, receive, send):
+        if scope["type"] == "lifespan":
+            assert (await receive())["type"] == "lifespan.startup"
+            events.append("startup")
+            await send({"type": "lifespan.startup.complete"})
+            assert (await receive())["type"] == "lifespan.shutdown"
+            events.append("shutdown")
+            await send({"type": "lifespan.shutdown.complete"})
+            return
+        await receive()
+        await send({"type": "http.response.start", "status": 200})
+        await send({"type": "http.response.body", "body": b"first", "more_body": True})
+        await release.wait()
+        await send({"type": "http.response.body", "body": b"last"})
+        await asyncio.sleep(0)
+        events.append("background-complete")
+
+    response = await asyncio.wait_for(
+        asgi.fetch(app, js.Request.new("http://example.com/proxy-lifetime"), env),
+        timeout=5,
+    )
+    try:
+        assert retained.length == 1
+        finalizer = retained.at(0)
+        assert asyncio.isfuture(finalizer)
+        assert not finalizer.done()
+    finally:
+        release.set()
+        assert await asyncio.wait_for(response.text(), timeout=5) == "firstlast"
+
+    await asyncio.wait_for(finalizer, timeout=5)
+    assert events == ["startup", "background-complete", "shutdown"]


### PR DESCRIPTION
A streaming ASGI response can return HTTP 200 while its `waitUntil` task rejects with a destroyed borrowed-proxy error. The finalizer introduced in #229 currently passes a Python task directly to JavaScript:

```python
wait_until(run_in_background(finalize_request()))
```

`waitUntil` retains the task after returning to Python. The implicit proxy is borrowed and expires at that return boundary, before JavaScript finishes assimilating the task. This can prevent request finalization, including background work and lifespan shutdown, from completing reliably after the response.

Create an explicitly owned proxy and destroy it when the finalizer task completes, following the WebSocket task-ownership pattern already used in #166. Existing task retention, exception logging, and the finalizer's `finally: await shutdown()` remain intact.

The new regression runs inside Workerd. It substitutes JavaScript `Array.push` for `wait_until`: both retain their argument and return no Promise. It retrieves and awaits that retained task after `fetch()` returns, rather than checking only the response body. It also verifies the complete streamed body and background work preceding lifespan shutdown. This catches the rejected task that an otherwise successful response can hide.

Related work: #229 introduced this HTTP finalizer; #166 provides the existing ownership pattern. The open worker-lifetime lifespan proposal #239 does not address this proxy lifetime.

### Test Plan

- Upstream ASGI Workerd suite, Python 3.13: **22 passed**, including snapshot creation and reload, with the fix.
- Same suite with the new test but unmodified main source: **21 passed, 1 failed**. The new test fails with `pyodide.ffi.JsException` reporting the destroyed borrowed proxy when awaiting the retained finalizer.
- Ruff check and format check passed using the CI-pinned Ruff 0.9.1; `git diff --check` passed.
- The equivalent narrow patch was also verified in a real deployment: the same 12 controlled requests produced the proxy error in all 12 runtime events before the patch and none afterward. Details: https://github.com/writerstead/writerstead.com/pull/322#issuecomment-5592011784

Local harness details: macOS, Node 24.19.0, uv 0.12.3, Workerd 1.20260815.1. The host harness used that existing pinned Workerd binary instead of its unpinned `npm i workerd` step. Python dependencies were constrained to releases before September 2 for the local test setup.

The wider local compatibility run could not execute Python 3.12 (Pyodide interpreter query failed during setup with `ModuleNotFoundError: No module named 'python'`) or Python 3.14 (the installed Workerd does not recognize `python_workers_314`). These are unverified configurations, not passing checks. The new regression is included in the existing ASGI suite for the normal CI matrix.
