### PR TITLE
fix(runtime-sdk): ensure finalize_request is alive inside wait_until call

### DIFF
--- a/packages/runtime-sdk/src/workers/asgi.py
+++ b/packages/runtime-sdk/src/workers/asgi.py
@@ -6,8 +6,9 @@ from typing import Any
 from urllib.parse import unquote
 
 import js
+from pyodide.ffi import create_proxy
 
-from workers import Context, Request, WorkerEntrypoint
+from workers import Context, Request, WorkerEntrypoint, wait_until
 from workers.utils import _to_js_headers
 
 ASGI = {"spec_version": "2.0", "version": "3.0"}
@@ -450,15 +451,15 @@ async def fetch(
     if request_task.done():
         await shutdown()
     else:
-        from workers import wait_until  # noqa: PLC0415
-
         async def finalize_request():
             try:
                 await request_task
             finally:
                 await shutdown()
 
-        wait_until(run_in_background(finalize_request()))
+        finalizer_task = run_in_background(finalize_request())
+        task_proxy = create_proxy(finalizer_task)
+        wait_until(task_proxy)
 
     return result
 

--- a/packages/runtime-sdk/tests/test_in_workerd.py
+++ b/packages/runtime-sdk/tests/test_in_workerd.py
@@ -15,6 +15,7 @@ WORKERD_TESTS = TEST_DIR / "workerd-test"
 WORKERS_PY = TEST_DIR.parent.parent / "cli"
 WORKERS_RUNTIME_SDK = TEST_DIR.parent / "src"
 DISK_SERVICE_NAME = "TEST_TMPDIR"
+BORROWED_PROXY_ERROR = "This borrowed proxy was automatically destroyed"
 
 
 def discover_workerd_tests():
@@ -62,6 +63,7 @@ def bundle_cache_dir(tmp_path_factory):
 )
 @pytest.mark.parametrize("test_dir, wd_test_file", discover_workerd_tests())
 def test_in_workerd(  # noqa: PLR0913, PLR0917  (too-many-arguments)
+    capfd,
     tmp_path,
     test_dir,
     wd_test_file,
@@ -153,3 +155,11 @@ def test_in_workerd(  # noqa: PLR0913, PLR0917  (too-many-arguments)
         cwd=target,
         check=True,
     )
+
+    # This happens in the background so it is not captured
+    # inside the worker. We need to look at the worker's logs
+    # to see if there are any errors.
+    captured = capfd.readouterr()
+    if test_dir.name == "asgi":
+        output = captured.out + captured.err
+        assert BORROWED_PROXY_ERROR not in output

--- a/packages/runtime-sdk/tests/test_in_workerd.py
+++ b/packages/runtime-sdk/tests/test_in_workerd.py
@@ -160,6 +160,5 @@ def test_in_workerd(  # noqa: PLR0913, PLR0917  (too-many-arguments)
     # inside the worker. We need to look at the worker's logs
     # to see if there are any errors.
     captured = capfd.readouterr()
-    if test_dir.name == "asgi":
-        output = captured.out + captured.err
-        assert BORROWED_PROXY_ERROR not in output
+    output = captured.out + captured.err
+    assert BORROWED_PROXY_ERROR not in output

--- a/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi/tests/test_asgi.py
@@ -5,7 +5,12 @@ import logging
 import js
 import pytest
 from pyodide.ffi import to_js
-from worker import STREAMING_CHUNK_SIZE, STREAMING_NUM_CHUNKS, example_hdr
+from worker import (
+    STREAMING_CHUNK_SIZE,
+    STREAMING_NUM_CHUNKS,
+    delayed_streaming_app,
+    example_hdr,
+)
 
 import asgi
 from workers import Request, env
@@ -87,6 +92,26 @@ async def test_streaming():
         start = i * STREAMING_CHUNK_SIZE
         chunk = body_bytes[start : start + STREAMING_CHUNK_SIZE]
         assert all(b == i % 256 for b in chunk)
+
+
+@pytest.mark.asyncio
+async def test_streaming_finalizer_survives_fetch_return():
+    delayed_streaming_app.reset()
+    response = await asyncio.wait_for(
+        env.SELF.fetch("http://example.com/delayed-stream"), timeout=5
+    )
+
+    # The first chunk makes fetch resolve while the ASGI task is still blocked.
+    assert not delayed_streaming_app.shutdown_complete.is_set()
+    reader = response.body.getReader()
+    first = await asyncio.wait_for(reader.read(), timeout=5)
+    assert first.value.to_bytes() == b"first"
+
+    delayed_streaming_app.release_stream.set()
+    second = await asyncio.wait_for(reader.read(), timeout=5)
+    assert second.value.to_bytes() == b"second"
+    assert (await asyncio.wait_for(reader.read(), timeout=5)).done
+    await asyncio.wait_for(delayed_streaming_app.shutdown_complete.wait(), timeout=5)
 
 
 class _ListHandler(logging.Handler):

--- a/packages/runtime-sdk/tests/workerd-test/asgi/worker.py
+++ b/packages/runtime-sdk/tests/workerd-test/asgi/worker.py
@@ -177,6 +177,37 @@ class StreamingApp:
             )
 
 
+class DelayedStreamingApp:
+    """Streams one chunk, then waits so fetch returns before finalization."""
+
+    def __init__(self):
+        self.release_stream = asyncio.Event()
+        self.shutdown_complete = asyncio.Event()
+
+    def reset(self):
+        self.release_stream = asyncio.Event()
+        self.shutdown_complete = asyncio.Event()
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "lifespan":
+            while True:
+                message = await receive()
+                if message["type"] == "lifespan.startup":
+                    await send({"type": "lifespan.startup.complete"})
+                elif message["type"] == "lifespan.shutdown":
+                    await send({"type": "lifespan.shutdown.complete"})
+                    self.shutdown_complete.set()
+                    return
+
+        await receive()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send(
+            {"type": "http.response.body", "body": b"first", "more_body": True}
+        )
+        await self.release_stream.wait()
+        await send({"type": "http.response.body", "body": b"second"})
+
+
 # ---------------------------------------------------------------------------
 # App instances and constants
 # ---------------------------------------------------------------------------
@@ -259,6 +290,7 @@ class MultiCookieApp:
 app = HeaderEchoApp()
 sse_app = SSEApp()
 streaming_app = StreamingApp()
+delayed_streaming_app = DelayedStreamingApp()
 scope_echo_app = ScopeEchoApp()
 late_failure_stream_app = LateFailureStreamApp()
 multi_cookie_app = MultiCookieApp()
@@ -277,6 +309,8 @@ class Default(WorkerEntrypoint):
             return await asgi.fetch(sse_app, request, self.env, self.ctx)
         elif path == "/stream":
             return await asgi.fetch(streaming_app, request, self.env, self.ctx)
+        elif path == "/delayed-stream":
+            return await asgi.fetch(delayed_streaming_app, request, self.env, self.ctx)
         elif path.startswith("/scope"):
             return await asgi.fetch(scope_echo_app, request, self.env, self.ctx)
         elif path == "/stream-late-failure":


### PR DESCRIPTION
While working on https://github.com/cloudflare/python-workers-examples/pull/103, I noticed that finalizer_task is gc-ed and cleaned up improperly inside wait_until.

This fixes it by wrapping it with create_proxy.

Probably the long term solution is to land #90 and make `self.ctx.waitUntil` and `workers.wait_until` work exactly the same, but #90 requires JSPI which isn't available in 0.26.0a2, so it needs  more discussion.