### PR TITLE
feat(cli): Add --skip-native-installation option to by pass installing packages in native venv

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,8 +28,55 @@ Then run via `uv run pywrangler`.
 
 ```bash
 uv run pywrangler --help
+# install packages
 uv run pywrangler sync
+# run dev server
+uv run pywrangler dev
+# deploy
+uv run pywrangler deploy
 ```
+
+### Advanced Usage
+
+#### Using local packages
+
+By default, pywrangler only allow installing packages from wheels, and not from source distributions.
+
+This is because Python workers needs cross-compiled wheels to
+run on the Worker runtime, while building from source distributions will output native wheels that are not compatible with the Worker runtime.
+
+However, when you are testing your local package that does not include
+any native extensions, you can use the `--allow-local` flag to allow installing
+it from source distribution.
+
+```
+uv run pywrangler sync --allow-local
+```
+
+#### Skip native installation
+
+pywrangler installs packages twice, once for the native environment and once for
+the Worker runtime environment.
+
+This has two purposes:
+1. To give a type information properly for the IDEs which is
+required for type checking and autocompletion.
+2. Make sure packages actually exist and are installable in the native environment.
+
+However, this has drawbacks:
+
+1. It takes more time to install packages.
+2. It may fail if the package is built only for the WASM environment / Worker runtime.
+
+In such cases, you can pass the `--skip-native` flag to skip the native installation, and only install the package for the Worker runtime.
+
+```
+uv run pywrangler sync --skip-native-installation
+```
+
+The skipped state is remembered by later `sync`, `dev`, and `deploy` commands
+until project dependencies or the pywrangler version changes. Run
+`pywrangler sync --force` to install native packages explicitly.
 
 ### Development
 

--- a/packages/cli/src/pywrangler/cli.py
+++ b/packages/cli/src/pywrangler/cli.py
@@ -140,16 +140,34 @@ def types_command(outdir: str | None, config: str | None) -> Never:
         "Defaults to the [tool.pywrangler] allow-build setting in pyproject.toml."
     ),
 )
+@click.option(
+    "--skip-native-installation/--no-skip-native-installation",
+    is_flag=True,
+    help=(
+        "Skip installing packages into the native virtual environment. "
+        "Use this option when you want to speed up the sync process (e.g. CI/CD), "
+        "or when you are using a package that is not available for the native platform."
+    ),
+)
 def sync_command(
-    force: bool = False, upgrade: bool = False, allow_build: bool | None = None
+    force: bool = False,
+    upgrade: bool = False,
+    allow_build: bool | None = None,
+    skip_native_installation: bool = False,
 ) -> None:
     """
     Installs Python packages from pyproject.toml into src/vendor.
 
-    Also creates a virtual env for Workers that you can use for testing.
+    By default, also creates a virtual env for Workers that you can use for testing.
     """
 
-    sync(force, directly_requested=True, upgrade=upgrade, allow_build=allow_build)
+    sync(
+        force,
+        directly_requested=True,
+        upgrade=upgrade,
+        allow_build=allow_build,
+        skip_native_installation=skip_native_installation,
+    )
     write_success("Sync process completed successfully.")
 
 

--- a/packages/cli/src/pywrangler/sync.py
+++ b/packages/cli/src/pywrangler/sync.py
@@ -58,6 +58,10 @@ def get_venv_workers_token_path() -> Path:
     return get_venv_workers_path() / ".synced"
 
 
+def get_native_skip_token_path() -> Path:
+    return get_venv_workers_path() / ".native-skipped"
+
+
 def get_vendor_modules_path() -> Path:
     return get_project_root() / "python_modules"
 
@@ -262,6 +266,9 @@ def _install_requirements_to_venv(constraints: list[str]) -> str | None:
         MANAGED_SDK_PACKAGE,
     ]
 
+    _remove_sync_token(get_venv_workers_token_path())
+    _remove_sync_token(get_native_skip_token_path())
+
     with temp_requirements_file(constraints) as constraints_file:
         result = run_command(
             [
@@ -346,20 +353,24 @@ def _get_vendor_package_versions() -> list[str]:
     return _parse_pip_freeze(result.stdout)
 
 
-def install_requirements(plan: InstallPlan, allow_build: bool = False) -> None:
+def install_requirements(
+    plan: InstallPlan, allow_build: bool = False, skip_native_installation: bool = False
+) -> None:
     # First, install to the Pyodide vendor directory. This determines the exact package
     # versions that will run in production.
     pyodide_error = _install_requirements_to_vendor(plan, allow_build=allow_build)
 
-    # Then install to .venv-workers using the pinned versions from vendor.
-    # This ensures host packages accurately reflect what will run in production.
-    # If the installation to the Pyodide vendor directory fails, use the original requirements
-    # to see if it fails in the native venv as well.
-    if pyodide_error:
-        host_constraints = []
-    else:
-        host_constraints = _get_vendor_package_versions()
-    native_error = _install_requirements_to_venv(host_constraints)
+    native_error = None
+    if not skip_native_installation:
+        # Then install to .venv-workers using the pinned versions from vendor.
+        # This ensures host packages accurately reflect what will run in production.
+        # If the installation to the Pyodide vendor directory fails, use the original
+        # requirements to see if it fails in the native venv as well.
+        if pyodide_error:
+            host_constraints = []
+        else:
+            host_constraints = _get_vendor_package_versions()
+        native_error = _install_requirements_to_venv(host_constraints)
 
     # Show the native error first (more likely to be actionable), then the Pyodide error.
     if native_error:
@@ -391,13 +402,24 @@ def install_requirements(plan: InstallPlan, allow_build: bool = False) -> None:
             )
         raise click.exceptions.Exit(code=1)
 
-    _log_installed_packages(get_venv_workers_path())
+    if skip_native_installation:
+        _record_native_skip()
+    _log_installed_packages(get_pyodide_venv_path())
 
 
 def _write_sync_token(token: Path) -> None:
     """Record the current workers-py version into the given sync token file."""
     token.parent.mkdir(parents=True, exist_ok=True)
     token.write_text(get_pywrangler_version())
+
+
+def _remove_sync_token(token: Path) -> None:
+    token.unlink(missing_ok=True)
+
+
+def _record_native_skip() -> None:
+    _remove_sync_token(get_venv_workers_token_path())
+    _write_sync_token(get_native_skip_token_path())
 
 
 def _read_sync_token_version(token: Path) -> str | None:
@@ -426,7 +448,7 @@ def _is_out_of_date(token: Path, time: float) -> bool:
     return False
 
 
-def is_sync_needed() -> bool:
+def is_sync_needed(skip_native_installation: bool = False) -> bool:
     """
     Checks if pyproject.toml or pylock.toml has been modified since the last
     sync, or if the workers-py version has changed since the last sync.
@@ -445,9 +467,16 @@ def is_sync_needed() -> bool:
     if lockfile.is_file():
         latest_mtime = max(latest_mtime, lockfile.stat().st_mtime)
 
-    return _is_out_of_date(get_vendor_token_path(), latest_mtime) or _is_out_of_date(
-        get_venv_workers_token_path(), latest_mtime
-    )
+    # Pyodide venv is out-of-date
+    if _is_out_of_date(get_vendor_token_path(), latest_mtime):
+        return True
+
+    # Native venv is out-of-date
+    if skip_native_installation:
+        return False
+    native_is_stale = _is_out_of_date(get_venv_workers_token_path(), latest_mtime)
+    skip_is_stale = _is_out_of_date(get_native_skip_token_path(), latest_mtime)
+    return native_is_stale and skip_is_stale
 
 
 def sync(
@@ -455,6 +484,7 @@ def sync(
     directly_requested: bool = False,
     upgrade: bool = False,
     allow_build: bool | None = None,
+    skip_native_installation: bool = False,
 ) -> None:
     # Check if requirements.txt does not exist.
     check_requirements_txt()
@@ -466,8 +496,12 @@ def sync(
         allow_build = bool(get_pywrangler_config().get("allow-build", False))
 
     # Check if sync is needed based on file timestamps
-    sync_needed = force or is_sync_needed()
+    sync_needed = force or is_sync_needed(
+        skip_native_installation=skip_native_installation
+    )
     if not sync_needed:
+        if skip_native_installation:
+            _record_native_skip()
         logger.debug("Sync not needed - no changes detected")
         if directly_requested:
             logger.warning(
@@ -480,8 +514,9 @@ def sync(
     # Check to make sure a wrangler config file exists.
     check_wrangler_config()
 
-    # Create .venv-workers if it doesn't exist
-    create_workers_venv()
+    # Create the native Workers venv unless it was explicitly disabled.
+    if not skip_native_installation:
+        create_workers_venv()
 
     # Set up Pyodide virtual env
     create_pyodide_venv()
@@ -492,4 +527,6 @@ def sync(
         logger.warning(
             "No dependencies found in [project.dependencies] section of pyproject.toml."
         )
-    install_requirements(plan, allow_build=allow_build)
+    install_requirements(
+        plan, allow_build=allow_build, skip_native_installation=skip_native_installation
+    )

--- a/packages/cli/tests/test_cli.py
+++ b/packages/cli/tests/test_cli.py
@@ -291,6 +291,53 @@ def test_sync_command_integration(dependencies, test_dir):  # noqa: C901 (test c
             )
 
 
+def test_sync_skip_native_install_integration(test_dir):
+    """Test that a skipped native install stays fresh until explicitly forced."""
+    create_test_pyproject(test_dir, ["click"])
+    create_test_wrangler_jsonc(test_dir, "src/worker.py")
+
+    result = subprocess.run(
+        ["uv", "run", "pywrangler", "sync", "--skip-native-installation"],
+        capture_output=True,
+        text=True,
+        cwd=test_dir,
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        f"sync --skip-native-installation failed: {result.stdout}\n{result.stderr}"
+    )
+    assert is_package_installed(test_dir / "python_modules", "click")
+    assert not (test_dir / ".venv-workers" / ".synced").exists()
+    assert (test_dir / ".venv-workers" / ".native-skipped").exists()
+    assert not (test_dir / ".venv-workers" / "pyvenv.cfg").exists()
+
+    plain_result = subprocess.run(
+        ["uv", "run", "pywrangler", "sync"],
+        capture_output=True,
+        text=True,
+        cwd=test_dir,
+        check=False,
+    )
+    assert plain_result.returncode == 0
+    assert not (test_dir / ".venv-workers" / ".synced").exists()
+    assert (test_dir / ".venv-workers" / ".native-skipped").exists()
+
+    force_result = subprocess.run(
+        ["uv", "run", "pywrangler", "sync", "--force"],
+        capture_output=True,
+        text=True,
+        cwd=test_dir,
+        check=False,
+    )
+    assert force_result.returncode == 0, (
+        f"forced native sync failed: {force_result.stdout}\n{force_result.stderr}"
+    )
+    assert (test_dir / ".venv-workers" / ".synced").exists()
+    assert not (test_dir / ".venv-workers" / ".native-skipped").exists()
+    assert (test_dir / ".venv-workers" / "pyvenv.cfg").exists()
+
+
 def test_sync_removes_stale_packages(test_dir):
     """Test that removing a dependency from pyproject.toml cleans it up from python_modules."""
     create_test_wrangler_jsonc(test_dir, "src/worker.py")
@@ -572,7 +619,11 @@ def test_sync_command_handles_missing_pyproject():
         assert "pyproject.toml not found" in result.stdout
 
 
-@patch.object(pywrangler_sync, "is_sync_needed", lambda: False)
+@patch.object(
+    pywrangler_sync,
+    "is_sync_needed",
+    lambda skip_native_installation=False: False,
+)
 @patch.object(pywrangler_sync, "install_requirements")
 def test_sync_command_with_unchanged_timestamps(
     mock_install_requirements, test_dir, caplog
@@ -596,7 +647,11 @@ def test_sync_command_with_unchanged_timestamps(
     mock_install_requirements.assert_not_called()
 
 
-@patch.object(pywrangler_sync, "is_sync_needed", lambda: True)
+@patch.object(
+    pywrangler_sync,
+    "is_sync_needed",
+    lambda skip_native_installation=False: True,
+)
 @patch.object(pywrangler_sync, "install_requirements")
 def test_sync_command_with_changed_timestamps(
     mock_install_requirements,
@@ -621,7 +676,11 @@ def test_sync_command_with_changed_timestamps(
     mock_install_requirements.assert_called_once()
 
 
-@patch.object(pywrangler_sync, "is_sync_needed", lambda: False)
+@patch.object(
+    pywrangler_sync,
+    "is_sync_needed",
+    lambda skip_native_installation=False: False,
+)
 @patch.object(pywrangler_sync, "install_requirements")
 @patch.object(pywrangler_sync, "resolve_requirements")
 def test_sync_command_with_force_flag(
@@ -643,6 +702,22 @@ def test_sync_command_with_force_flag(
 
     # Verify that all the sync functions were called despite the timestamp check
     mock_install_requirements.assert_called_once()
+
+
+@patch("pywrangler.cli.sync")
+def test_sync_command_with_skip_native_flag(mock_sync):
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["sync", "--skip-native-installation"])
+
+    assert result.exit_code == 0
+    mock_sync.assert_called_once_with(
+        False,
+        directly_requested=True,
+        upgrade=False,
+        allow_build=None,
+        skip_native_installation=True,
+    )
 
 
 def test_sync_command_handles_missing_wrangler_config(test_dir, caplog):

--- a/packages/cli/tests/test_version_sync.py
+++ b/packages/cli/tests/test_version_sync.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -69,6 +70,25 @@ def test_get_vendor_package_versions_disables_color():
 
 
 class TestInstallRequirements:
+    @patch.object(pywrangler_sync, "_log_installed_packages")
+    @patch.object(pywrangler_sync, "_install_requirements_to_vendor")
+    @patch.object(pywrangler_sync, "_get_vendor_package_versions")
+    @patch.object(pywrangler_sync, "_install_requirements_to_venv")
+    def test_skip_native_only_installs_vendor_packages(
+        self, mock_venv, mock_get_vendor, mock_vendor, mock_log, tmp_path
+    ):
+        mock_vendor.return_value = None
+        plan = _make_plan(tmp_path, [("some-package", "1.0.0")])
+
+        with patch.object(pywrangler_sync, "_record_native_skip") as mock_record:
+            pywrangler_sync.install_requirements(plan, skip_native_installation=True)
+
+        mock_vendor.assert_called_once_with(plan, allow_build=False)
+        mock_get_vendor.assert_not_called()
+        mock_venv.assert_not_called()
+        mock_log.assert_called_once_with(pywrangler_sync.get_pyodide_venv_path())
+        mock_record.assert_called_once_with()
+
     @patch.object(pywrangler_sync, "_install_requirements_to_vendor")
     @patch.object(pywrangler_sync, "_get_vendor_package_versions")
     @patch.object(pywrangler_sync, "_install_requirements_to_venv")
@@ -278,6 +298,98 @@ class TestSyncTokenVersion:
 
         assert pywrangler_sync.is_sync_needed() is False
 
+    def test_skip_native_ignores_missing_native_token(
+        self, project_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pywrangler_sync, "get_pywrangler_version", lambda: "1.2.3")
+        pywrangler_sync._write_sync_token(pywrangler_sync.get_vendor_token_path())
+
+        assert pywrangler_sync.is_sync_needed(skip_native_installation=True) is False
+        assert pywrangler_sync.is_sync_needed() is True
+
+    def test_recorded_native_skip_is_fresh_for_plain_sync(
+        self, project_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pywrangler_sync, "get_pywrangler_version", lambda: "1.2.3")
+        pywrangler_sync._write_sync_token(pywrangler_sync.get_vendor_token_path())
+
+        pywrangler_sync._record_native_skip()
+
+        assert pywrangler_sync.get_native_skip_token_path().is_file()
+        assert not pywrangler_sync.get_venv_workers_token_path().exists()
+        assert pywrangler_sync.is_sync_needed() is False
+
+    def test_recorded_native_skip_is_stale_after_version_change(
+        self, project_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pywrangler_sync, "get_pywrangler_version", lambda: "1.2.3")
+        pywrangler_sync._write_sync_token(pywrangler_sync.get_vendor_token_path())
+        pywrangler_sync._record_native_skip()
+
+        monkeypatch.setattr(pywrangler_sync, "get_pywrangler_version", lambda: "1.2.4")
+
+        assert pywrangler_sync.is_sync_needed() is True
+
+    def test_recorded_native_skip_is_stale_after_pyproject_change(
+        self, project_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pywrangler_sync, "get_pywrangler_version", lambda: "1.2.3")
+        pywrangler_sync._write_sync_token(pywrangler_sync.get_vendor_token_path())
+        pywrangler_sync._record_native_skip()
+        pyproject = project_root / "pyproject.toml"
+        future_ns = (
+            pywrangler_sync.get_native_skip_token_path().stat().st_mtime_ns
+            + 1_000_000_000
+        )
+
+        os.utime(pyproject, ns=(future_ns, future_ns))
+
+        assert pywrangler_sync.is_sync_needed() is True
+
+    def test_native_install_replaces_recorded_skip(
+        self, project_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pywrangler_sync, "get_pywrangler_version", lambda: "1.2.3")
+        pywrangler_sync._record_native_skip()
+        result = type("Result", (), {"returncode": 0, "stdout": ""})()
+        monkeypatch.setattr(
+            pywrangler_sync, "run_command", lambda *args, **kwargs: result
+        )
+
+        assert pywrangler_sync._install_requirements_to_venv([]) is None
+
+        assert pywrangler_sync.get_venv_workers_token_path().is_file()
+        assert not pywrangler_sync.get_native_skip_token_path().exists()
+
+    def test_failed_native_install_clears_recorded_skip(
+        self, project_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pywrangler_sync, "get_pywrangler_version", lambda: "1.2.3")
+        pywrangler_sync._record_native_skip()
+        result = type("Result", (), {"returncode": 1, "stdout": "failed"})()
+        monkeypatch.setattr(
+            pywrangler_sync, "run_command", lambda *args, **kwargs: result
+        )
+
+        assert pywrangler_sync._install_requirements_to_venv([]) == "failed"
+
+        assert not pywrangler_sync.get_venv_workers_token_path().exists()
+        assert not pywrangler_sync.get_native_skip_token_path().exists()
+
+    def test_noop_skip_records_persistent_state(
+        self, project_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pywrangler_sync, "get_pywrangler_version", lambda: "1.2.3")
+        monkeypatch.setattr(pywrangler_sync, "check_requirements_txt", lambda: None)
+        monkeypatch.setattr(pywrangler_sync, "get_pywrangler_config", lambda: {})
+        monkeypatch.setattr(pywrangler_sync, "is_sync_needed", lambda **kwargs: False)
+        pywrangler_sync._write_sync_token(pywrangler_sync.get_venv_workers_token_path())
+
+        pywrangler_sync.sync(skip_native_installation=True)
+
+        assert pywrangler_sync.get_native_skip_token_path().is_file()
+        assert not pywrangler_sync.get_venv_workers_token_path().exists()
+
     def test_sync_needed_when_version_changes(
         self, project_root: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -385,7 +497,6 @@ class TestSyncNeededWithLockfile:
 
         lockfile = project_root / "pylock.toml"
         lockfile.write_text("click==8.1.7\n")
-        import os
         import time
 
         future = time.time() + 10


### PR DESCRIPTION
This adds a new `--skip-native-installation` flag to `pywrangler sync`.

When this flag is enabled, pywrangler will install packages only to the Pyodide venv, not in native venv. This is useful in two scenarios.

1. When there is no pre-compiled wheel for the native environment. (e.g. [`psycopg-c`](https://pypi.org/project/psycopg-c/#files))

2. In CI, when users don't need auto completion, type hints etc.