### PR TITLE
test(runtime-sdk): test http/urllib builtin packages

### DIFF
--- a/packages/runtime-sdk/tests/test_in_workerd.py
+++ b/packages/runtime-sdk/tests/test_in_workerd.py
@@ -84,6 +84,9 @@ def test_in_workerd(  # noqa: PLR0913, PLR0917  (too-many-arguments)
             "TODO: enable me after https://github.com/cloudflare/workerd/pull/7200 lands in wrangler"
         )
 
+    if test_dir.name == "http-client" and python_version < "3.14":
+        pytest.skip("HTTP client compatibility tests require Python 3.14 or newer")
+
     color = pytestconfig.get_terminal_writer().hasmarkup
     target = tmp_path / test_dir.name
     disk_service_dir = target / DISK_SERVICE_NAME

--- a/packages/runtime-sdk/tests/workerd-test/http-client/http-client.wd-test
+++ b/packages/runtime-sdk/tests/workerd-test/http-client/http-client.wd-test
@@ -1,0 +1,45 @@
+using Workerd = import "/workerd/workerd.capnp";
+
+const client :Workerd.Worker = (
+  modules = [
+    (name = "worker.py", pythonModule = embed "worker.py"),
+    %PYTHON_MODULES
+  ],
+  bindings = [
+    (name = "color", json = "%COLOR"),
+  ],
+  globalOutbound = "external",
+  compatibilityDate = "%COMPAT_DATE",
+  compatibilityFlags = ["python_workers", "service_binding_extra_handlers"],
+);
+
+const origin :Workerd.Worker = (
+  modules = [
+    (name = "origin.py", pythonModule = embed "origin.py"),
+    %PYTHON_MODULES
+  ],
+  compatibilityDate = "%COMPAT_DATE",
+  compatibilityFlags = ["python_workers"],
+);
+
+const unitTests :Workerd.Config = (
+  services = [
+    (
+      name = "external",
+      external = (
+        address = "loopback:raw-http-origin",
+        tcp = (),
+      ),
+    ),
+    (name = "http-client", worker = .client),
+    (name = "http-origin", worker = .origin),
+  ],
+  sockets = [
+    (
+      name = "raw-http-origin",
+      address = "loopback:raw-http-origin",
+      http = (),
+      service = "http-origin",
+    ),
+  ],
+);

--- a/packages/runtime-sdk/tests/workerd-test/http-client/origin.py
+++ b/packages/runtime-sdk/tests/workerd-test/http-client/origin.py
@@ -1,0 +1,60 @@
+import json
+
+from workers import Response, WorkerEntrypoint
+
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        url = request.url
+        path = url.split("?", 1)[0].rsplit("/", 1)[-1]
+
+        match path:
+            case "echo":
+                return Response.json(
+                    {
+                        "method": request.method,
+                        "url": url,
+                        "custom": request.headers.get("X-Custom"),
+                        "content_type": request.headers.get("Content-Type"),
+                        "body": (await request.bytes()).decode(),
+                    }
+                )
+            case "body":
+                return Response(await request.text())
+            case "lines":
+                return Response("first\nsecond\nthird\n")
+            case "head":
+                return Response(
+                    "body that HEAD must not expose", headers={"X-Origin": "head"}
+                )
+            case "redirect":
+                return Response(
+                    "",
+                    status=302,
+                    headers={"Location": "http://example.com:80/final"},
+                )
+            case "final":
+                return Response("redirected")
+            case "error":
+                return Response(
+                    "teapot body",
+                    status=418,
+                    status_text="I'm a Teapot",
+                    headers={"X-Error": "expected"},
+                )
+            case "auth":
+                if request.headers.get("Authorization") != "Basic dXNlcjpwYXNz":
+                    return Response(
+                        "authentication required",
+                        status=401,
+                        headers={"WWW-Authenticate": 'Basic realm="compat"'},
+                    )
+                return Response("authenticated")
+            case "set-cookie":
+                return Response(
+                    "cookie set", headers={"Set-Cookie": "session=abc; Path=/"}
+                )
+            case "cookie":
+                return Response(request.headers.get("Cookie") or "")
+            case _:
+                return Response(json.dumps({"unexpected_url": url}), status=404)

--- a/packages/runtime-sdk/tests/workerd-test/http-client/pyproject.toml
+++ b/packages/runtime-sdk/tests/workerd-test/http-client/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "http-client-compatibility-test"
+version = "0.0.0"
+requires-python = ">=3.14"
+dependencies = ["pytest"]

--- a/packages/runtime-sdk/tests/workerd-test/http-client/tests/test_http_client.py
+++ b/packages/runtime-sdk/tests/workerd-test/http-client/tests/test_http_client.py
@@ -1,0 +1,162 @@
+import http.client
+import io
+import json
+
+import pytest
+
+HOST = "example.com"
+PORT = 80
+
+
+def connection():
+    return http.client.HTTPConnection(HOST, PORT)
+
+
+def get_json(response):
+    return json.loads(response.read())
+
+
+def test_http_connection_explicit_connect_and_close():
+    conn = connection()
+    try:
+        conn.connect()
+        assert conn.sock is not None
+    finally:
+        conn.close()
+    assert conn.sock is None
+
+
+def test_http_connection_lazy_connect_get_path_query_and_headers():
+    conn = connection()
+    try:
+        conn.request("GET", "/echo?name=workers", headers={"X-Custom": "present"})
+        payload = get_json(conn.getresponse())
+    finally:
+        conn.close()
+
+    assert payload == {
+        "method": "GET",
+        "url": "http://example.com/echo?name=workers",
+        "custom": "present",
+        "content_type": None,
+        "body": "",
+    }
+
+
+@pytest.mark.parametrize(
+    "body", ["text body", b"bytes body", bytearray(b"bytearray body")]
+)
+def test_http_connection_post_string_and_bytes_like_bodies(body):
+    conn = connection()
+    try:
+        conn.request("POST", "/body", body=body)
+        expected = bytes(body, "latin-1") if isinstance(body, str) else bytes(body)
+        assert conn.getresponse().read() == expected
+    finally:
+        conn.close()
+
+
+def test_http_connection_post_file_like_and_iterable_bodies():
+    for body in (io.BytesIO(b"file body"), [b"iter", b"able"]):
+        conn = connection()
+        try:
+            conn.request("POST", "/body", body=body, encode_chunked=True)
+            expected = b"file body" if hasattr(body, "read") else b"iterable"
+            assert conn.getresponse().read() == expected
+        finally:
+            conn.close()
+
+
+def test_http_connection_low_level_request_assembly_and_send():
+    conn = connection()
+    try:
+        conn.putrequest("POST", "/echo")
+        conn.putheader("Content-Length", "3")
+        conn.putheader("X-Custom", "low-level")
+        conn.endheaders()
+        conn.send(b"raw")
+        assert get_json(conn.getresponse()) == {
+            "method": "POST",
+            "url": "http://example.com/echo",
+            "custom": "low-level",
+            "content_type": None,
+            "body": "raw",
+        }
+    finally:
+        conn.close()
+
+
+def test_http_response_metadata_and_headers():
+    conn = connection()
+    try:
+        conn.request("GET", "/echo")
+        response = conn.getresponse()
+        assert response.status == 200
+        assert response.reason == "OK"
+        assert response.version == 11
+        assert response.getheader("content-type") == "application/json"
+        assert response.getheaders()
+        response.read()
+    finally:
+        conn.close()
+
+
+def test_http_response_read_methods_and_peek():
+    conn = connection()
+    try:
+        conn.request("GET", "/lines")
+        response = conn.getresponse()
+        assert response.peek(5).startswith(b"first")
+        assert response.read(5) == b"first"
+        target = bytearray(1)
+        assert response.readinto(target) == 1
+        assert target == b"\n"
+        assert response.read1(6) == b"second"
+        assert response.read() == b"\nthird\n"
+    finally:
+        conn.close()
+
+
+def test_http_response_line_iteration():
+    conn = connection()
+    try:
+        conn.request("GET", "/lines")
+        assert list(conn.getresponse()) == [b"first\n", b"second\n", b"third\n"]
+    finally:
+        conn.close()
+
+
+def test_http_connection_head_has_no_response_body():
+    conn = connection()
+    try:
+        conn.request("HEAD", "/head")
+        response = conn.getresponse()
+        assert response.status == 200
+        assert response.getheader("X-Origin") == "head"
+        assert response.read() == b""
+    finally:
+        conn.close()
+
+
+def test_http_connection_reuse_and_reconnect_after_close():
+    conn = connection()
+    try:
+        conn.request("GET", "/body")
+        assert conn.getresponse().read() == b""
+        conn.request("GET", "/lines")
+        assert conn.getresponse().read() == b"first\nsecond\nthird\n"
+        conn.close()
+        conn.request("GET", "/final")
+        assert conn.getresponse().read() == b"redirected"
+    finally:
+        conn.close()
+
+
+def test_http_connection_state_and_validation_errors():
+    conn = connection()
+    with pytest.raises(http.client.ResponseNotReady):
+        conn.getresponse()
+    with pytest.raises(http.client.CannotSendHeader):
+        conn.putheader("X-Test", "value")
+    with pytest.raises(ValueError):
+        conn.request("GET\n", "/echo")

--- a/packages/runtime-sdk/tests/workerd-test/http-client/tests/test_urllib_request.py
+++ b/packages/runtime-sdk/tests/workerd-test/http-client/tests/test_urllib_request.py
@@ -1,0 +1,121 @@
+import io
+import json
+import os
+import tempfile
+import urllib.error
+import urllib.request
+import urllib.response
+from email.message import Message
+from http.cookiejar import CookieJar
+
+import pytest
+
+BASE_URL = "http://example.com:80"
+
+
+def test_urlopen_string_request_and_context_manager():
+    with urllib.request.urlopen(f"{BASE_URL}/final") as response:
+        assert response.status == 200
+        assert response.read() == b"redirected"
+
+
+def test_request_method_headers_and_data():
+    request = urllib.request.Request(
+        f"{BASE_URL}/echo",
+        data=b"request body",
+        headers={"X-Custom": "urllib"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request) as response:
+        assert json.loads(response.read()) == {
+            "method": "POST",
+            "url": "http://example.com:80/echo",
+            "custom": "urllib",
+            "content_type": "application/x-www-form-urlencoded",
+            "body": "request body",
+        }
+
+
+def test_build_opener_with_http_handler():
+    opener = urllib.request.build_opener(urllib.request.HTTPHandler())
+    with opener.open(f"{BASE_URL}/final") as response:
+        assert response.read() == b"redirected"
+
+
+def test_install_opener_is_restored():
+    opener_state = vars(urllib.request)
+    previous = opener_state["_opener"]
+    opener = urllib.request.build_opener(urllib.request.HTTPHandler())
+    try:
+        urllib.request.install_opener(opener)
+        with urllib.request.urlopen(f"{BASE_URL}/final") as response:
+            assert response.read() == b"redirected"
+    finally:
+        urllib.request.install_opener(previous)
+
+
+def test_urlopen_follows_redirects():
+    with urllib.request.urlopen(f"{BASE_URL}/redirect") as response:
+        assert response.geturl() == f"{BASE_URL}/final"
+        assert response.read() == b"redirected"
+
+
+def test_http_error_exposes_readable_body_and_metadata():
+    with pytest.raises(urllib.error.HTTPError) as raised:
+        urllib.request.urlopen(f"{BASE_URL}/error")
+
+    error = raised.value
+    try:
+        assert error.code == 418
+        assert error.reason == "I'm a Teapot"
+        assert error.headers["X-Error"] == "expected"
+        assert error.read() == b"teapot body"
+    finally:
+        error.close()
+
+
+def test_basic_auth_password_manager():
+    password_manager = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+    password_manager.add_password(None, BASE_URL, "user", "pass")
+    opener = urllib.request.build_opener(
+        urllib.request.HTTPBasicAuthHandler(password_manager)
+    )
+    with opener.open(f"{BASE_URL}/auth") as response:
+        assert response.read() == b"authenticated"
+
+
+def test_cookie_processor_persists_cookies():
+    cookie_jar = CookieJar()
+    opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookie_jar))
+    with opener.open(f"{BASE_URL}/set-cookie"):
+        pass
+    with opener.open(f"{BASE_URL}/cookie") as response:
+        assert response.read() == b"session=abc"
+
+
+def test_urlretrieve_writes_response_to_filesystem():
+    descriptor, path = tempfile.mkstemp()
+    os.close(descriptor)
+    try:
+        filename, headers = urllib.request.urlretrieve(f"{BASE_URL}/final", path)
+        assert filename == path
+        assert headers.get_content_type() == "text/plain"
+        with open(path, "rb") as downloaded:
+            assert downloaded.read() == b"redirected"
+    finally:
+        os.unlink(path)
+
+
+def test_url_error_and_custom_handler_behavior():
+    class LocalHandler(urllib.request.BaseHandler):
+        def default_open(self, request):
+            return urllib.response.addinfourl(
+                io.BytesIO(b"handled locally"), Message(), request.full_url, code=200
+            )
+
+    opener = urllib.request.build_opener(LocalHandler())
+    with opener.open("custom://example.invalid/resource") as response:
+        assert response.read() == b"handled locally"
+
+    with pytest.raises(urllib.error.URLError):
+        urllib.request.urlopen("ftp://example.com/resource")

--- a/packages/runtime-sdk/tests/workerd-test/http-client/worker.py
+++ b/packages/runtime-sdk/tests/workerd-test/http-client/worker.py
@@ -1,0 +1,14 @@
+import os
+
+import pytest
+
+from workers import WorkerEntrypoint
+
+
+class Default(WorkerEntrypoint):
+    def test(self):
+        os.chdir("/session/metadata/tests")
+        args = [".", "-vv"]
+        if self.env.color:
+            args.append("--color=yes")
+        assert pytest.main(args) == 0

--- a/packages/runtime-sdk/tests/workerd-test/http-client/wrangler.jsonc
+++ b/packages/runtime-sdk/tests/workerd-test/http-client/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+    "name": "http-client-compatibility-test",
+    "compatibility_date": "%COMPAT_DATE",
+    "compatibility_flags": ["python_workers"]
+}


### PR DESCRIPTION
Since we now support TCP sockets, these libraries work in workers.